### PR TITLE
refactor(message)!: replace context with deadline

### DIFF
--- a/examples/message/main.go
+++ b/examples/message/main.go
@@ -19,16 +19,17 @@ func main() {
 	nack := func(err error) { fmt.Printf("✗ Message rejected: %v\n", err) }
 
 	// Create messages using the new functional options API
+	deadline := time.Now().Add(30 * time.Second)
 	in := channel.FromValues(
 		message.New(12,
-			message.WithContext[int](ctx),
+			message.WithDeadline[int](deadline),
 			message.WithAcking[int](ack, nack),
 			message.WithID[int]("msg-001"),
 			message.WithProperty[int]("source", "orders-queue"),
 			message.WithCreatedAt[int](time.Now()),
 		),
 		message.New(42,
-			message.WithContext[int](ctx),
+			message.WithDeadline[int](deadline),
 			message.WithAcking[int](ack, nack),
 			message.WithID[int]("msg-002"),
 			message.WithProperty[int]("source", "orders-queue"),

--- a/message/properties.go
+++ b/message/properties.go
@@ -9,9 +9,6 @@ import (
 // Reserved property keys for gopipe internal use.
 // User-defined properties should NOT use the "gopipe." prefix.
 const (
-	// PropContext stores the runtime context (not serialized directly).
-	PropContext = "gopipe.internal.context"
-
 	// PropID is the unique message identifier.
 	PropID = "gopipe.message.id"
 
@@ -23,6 +20,9 @@ const (
 
 	// PropRetryCount tracks how many times the message has been retried.
 	PropRetryCount = "gopipe.message.retry_count"
+
+	// PropDeadline stores the message processing deadline.
+	PropDeadline = "gopipe.message.deadline"
 )
 
 // Properties provides thread-safe access to message properties.


### PR DESCRIPTION
Remove the context property and WithContext functional option from the message package.
Instead, provide WithDeadline to directly set message processing deadlines.

BREAKING CHANGE: The WithContext option and Context() method have been removed.
Users should use WithDeadline() to set deadlines directly instead of using context.
The Deadline() method now retrieves the deadline from message properties rather than
extracting it from a context.

Changes:
- Remove PropContext constant from properties
- Add PropDeadline constant for storing deadlines
- Replace WithContext[T] with WithDeadline[T]
- Remove Context() method from Message
- Update Deadline() to read from properties instead of context
- Update all tests and examples to use WithDeadline