### PR TITLE
fix(message): resolve data race in subscriber config test

### DIFF
--- a/message/subscriber_test.go
+++ b/message/subscriber_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -209,10 +210,9 @@ func TestSubscriber_Subscribe(t *testing.T) {
 
 	t.Run("subscription with config options", func(t *testing.T) {
 		mock := newMockReceiver()
-		callCount := 0
+		var callCount atomic.Int32
 		mock.receiveFunc = func(ctx context.Context, topic string) ([]*Message, error) {
-			callCount++
-			if callCount > 2 {
+			if callCount.Add(1) > 2 {
 				return nil, errors.New("done")
 			}
 			return []*Message{


### PR DESCRIPTION
## Summary

- Fixed data race in `message/subscriber_test.go` `subscription_with_config_options` test
- The `callCount` variable was accessed from multiple goroutines without synchronization due to `Concurrency: 2` config
- Changed from plain `int` to `atomic.Int32` for thread-safe access

## Test plan

- [x] Verified fix with `go test -race ./message/...`
- [x] Full test suite passes with race detector: `go test -race ./...`
- [x] Build and vet checks pass: `make build && make vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)