### PR TITLE
refactor(message): use google/uuid instead of custom implementation

### DIFF
--- a/message/attributes.go
+++ b/message/attributes.go
@@ -1,5 +1,10 @@
 package message
 
+import "github.com/google/uuid"
+
+// NewID generates a new unique message ID (UUID v4).
+func NewID() string { return uuid.NewString() }
+
 // Attributes is a map of message context attributes per CloudEvents spec.
 // CloudEvents defines attributes as the metadata that describes the event.
 //

--- a/message/go.mod
+++ b/message/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/fxsml/gopipe/channel v0.11.0
 	github.com/fxsml/gopipe/pipe v0.11.0
+	github.com/google/uuid v1.6.0
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/message/handler.go
+++ b/message/handler.go
@@ -2,8 +2,6 @@ package message
 
 import (
 	"context"
-	"crypto/rand"
-	"fmt"
 	"reflect"
 	"time"
 )
@@ -123,24 +121,15 @@ func (h *commandHandler[C, E]) Handle(ctx context.Context, msg *Message) ([]*Mes
 	outputs := make([]*Message, len(events))
 	for i, event := range events {
 		outputs[i] = New(event, Attributes{
-			"id":          newUUID(),
-			"specversion": "1.0",
-			"type":        eventType,
-			"source":      h.source,
-			"time":        time.Now().UTC().Format(time.RFC3339),
+			AttrID:          NewID(),
+			AttrSpecVersion: "1.0",
+			AttrType:        eventType,
+			AttrSource:      h.source,
+			AttrTime:        time.Now().UTC().Format(time.RFC3339),
 		}, nil)
 	}
 
 	return outputs, nil
-}
-
-// newUUID generates a UUID v4 string using crypto/rand.
-func newUUID() string {
-	var u [16]byte
-	_, _ = rand.Read(u[:])
-	u[6] = (u[6] & 0x0f) | 0x40 // version 4
-	u[8] = (u[8] & 0x3f) | 0x80 // variant 10
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
 }
 
 // Verify handlers implement Handler.

--- a/message/handler_test.go
+++ b/message/handler_test.go
@@ -187,27 +187,3 @@ func TestNewCommandHandler(t *testing.T) {
 		}
 	})
 }
-
-func TestNewUUID(t *testing.T) {
-	t.Run("generates valid UUID v4 format", func(t *testing.T) {
-		uuid := newUUID()
-		// UUID format: 8-4-4-4-12
-		if len(uuid) != 36 {
-			t.Errorf("expected UUID length 36, got %d", len(uuid))
-		}
-		if uuid[8] != '-' || uuid[13] != '-' || uuid[18] != '-' || uuid[23] != '-' {
-			t.Errorf("invalid UUID format: %s", uuid)
-		}
-	})
-
-	t.Run("generates unique UUIDs", func(t *testing.T) {
-		uuids := make(map[string]bool)
-		for i := 0; i < 1000; i++ {
-			uuid := newUUID()
-			if uuids[uuid] {
-				t.Errorf("duplicate UUID generated: %s", uuid)
-			}
-			uuids[uuid] = true
-		}
-	})
-}


### PR DESCRIPTION
## Summary

Replace custom UUID v4 implementation with well-tested `github.com/google/uuid` package.

### Changes

- Add `NewID()` function in `message/attributes.go` using `uuid.NewString()`
- Replace custom `newUUID()` with `NewID()` in command handler
- Use attribute constants (`AttrID`, `AttrType`, etc.) in handler output
- Remove `TestNewUUID` test (library is already well-tested)

### Benefits

- Well-tested, widely-used library
- Reduces custom code to maintain
- Exposes `NewID()` for users to generate message IDs

Closes #65

## Test plan

- [x] All existing tests pass
- [x] `make test && make build && make vet`

🤖 Generated with [Claude Code](https://claude.ai/code)