### PR TITLE
feat(middleware): add Subject middleware for dynamic subject extraction

### DIFF
--- a/message/middleware/subject.go
+++ b/message/middleware/subject.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/fxsml/gopipe/message"
+)
+
+// subjecter is satisfied by types with a Subject method.
+// Uses duck typing - users implement Subject() string on their types.
+type subjecter interface {
+	Subject() string
+}
+
+// Subject sets AttrSubject on output messages from data implementing Subject().
+// If the output message's Data has a Subject() string method, its return value
+// is used as the CloudEvents subject attribute.
+func Subject() message.Middleware {
+	return func(next message.ProcessFunc) message.ProcessFunc {
+		return func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			outputs, err := next(ctx, msg)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, out := range outputs {
+				if s, ok := out.Data.(subjecter); ok {
+					if out.Attributes == nil {
+						out.Attributes = make(message.Attributes)
+					}
+					out.Attributes[message.AttrSubject] = s.Subject()
+				}
+			}
+
+			return outputs, nil
+		}
+	}
+}

--- a/message/middleware/subject_test.go
+++ b/message/middleware/subject_test.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fxsml/gopipe/message"
+)
+
+// orderCreated implements Subject() for testing.
+type orderCreated struct {
+	OrderID string
+	Status  string
+}
+
+func (o orderCreated) Subject() string { return o.OrderID }
+
+// simpleEvent does not implement Subject().
+type simpleEvent struct {
+	Data string
+}
+
+func TestSubject(t *testing.T) {
+	t.Run("sets subject from Subjecter", func(t *testing.T) {
+		handler := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			return []*message.Message{
+				message.New(orderCreated{OrderID: "ORD-123", Status: "created"}, nil, nil),
+			}, nil
+		}
+
+		wrapped := Subject()(handler)
+		outputs, err := wrapped(context.Background(), message.New(nil, nil, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(outputs) != 1 {
+			t.Fatalf("expected 1 output, got %d", len(outputs))
+		}
+
+		subject := outputs[0].Attributes[message.AttrSubject]
+		if subject != "ORD-123" {
+			t.Errorf("expected subject 'ORD-123', got %v", subject)
+		}
+	})
+
+	t.Run("skips non-Subjecter data", func(t *testing.T) {
+		handler := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			return []*message.Message{
+				message.New(simpleEvent{Data: "test"}, nil, nil),
+			}, nil
+		}
+
+		wrapped := Subject()(handler)
+		outputs, err := wrapped(context.Background(), message.New(nil, nil, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(outputs) != 1 {
+			t.Fatalf("expected 1 output, got %d", len(outputs))
+		}
+
+		if _, exists := outputs[0].Attributes[message.AttrSubject]; exists {
+			t.Error("expected no subject attribute for non-Subjecter")
+		}
+	})
+
+	t.Run("handles nil attributes", func(t *testing.T) {
+		handler := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			return []*message.Message{
+				{Data: orderCreated{OrderID: "ORD-456"}}, // nil Attributes
+			}, nil
+		}
+
+		wrapped := Subject()(handler)
+		outputs, err := wrapped(context.Background(), message.New(nil, nil, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		subject := outputs[0].Attributes[message.AttrSubject]
+		if subject != "ORD-456" {
+			t.Errorf("expected subject 'ORD-456', got %v", subject)
+		}
+	})
+
+	t.Run("handles multiple outputs", func(t *testing.T) {
+		handler := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			return []*message.Message{
+				message.New(orderCreated{OrderID: "ORD-1"}, nil, nil),
+				message.New(simpleEvent{Data: "skip"}, nil, nil),
+				message.New(orderCreated{OrderID: "ORD-2"}, nil, nil),
+			}, nil
+		}
+
+		wrapped := Subject()(handler)
+		outputs, err := wrapped(context.Background(), message.New(nil, nil, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(outputs) != 3 {
+			t.Fatalf("expected 3 outputs, got %d", len(outputs))
+		}
+
+		if outputs[0].Attributes[message.AttrSubject] != "ORD-1" {
+			t.Errorf("expected first subject 'ORD-1', got %v", outputs[0].Attributes[message.AttrSubject])
+		}
+		if _, exists := outputs[1].Attributes[message.AttrSubject]; exists {
+			t.Error("expected no subject on second output")
+		}
+		if outputs[2].Attributes[message.AttrSubject] != "ORD-2" {
+			t.Errorf("expected third subject 'ORD-2', got %v", outputs[2].Attributes[message.AttrSubject])
+		}
+	})
+
+	t.Run("propagates handler errors", func(t *testing.T) {
+		handler := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+			return nil, message.ErrNoHandler
+		}
+
+		wrapped := Subject()(handler)
+		_, err := wrapped(context.Background(), message.New(nil, nil, nil))
+		if err != message.ErrNoHandler {
+			t.Errorf("expected ErrNoHandler, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add middleware that automatically sets `AttrSubject` on output messages when the data implements a `Subject() string` method.

Uses **duck typing** - no interface import required. Users just add a `Subject()` method to their event types.

## Usage

```go
// Enable middleware
router.Use(middleware.Subject())

// Event type with Subject method
type OrderCreated struct {
    OrderID string `json:"order_id"`
    Status  string `json:"status"`
}

func (o OrderCreated) Subject() string {
    return o.OrderID
}
```

Output messages will automatically have `subject: "ORD-123"` attribute set.

## Design

- Private `subjecter` interface in middleware package (duck typing)
- Skips data that doesn't implement `Subject()`
- Handles nil Attributes map
- Works with multiple outputs

## Test plan

- [x] Sets subject from Subjecter implementation
- [x] Skips non-Subjecter data
- [x] Handles nil attributes
- [x] Handles multiple outputs
- [x] Propagates handler errors

🤖 Generated with [Claude Code](https://claude.ai/code)