### PR TITLE
feat(message): implement graceful loopback shutdown

### DIFF
--- a/docs/plans/0012-graceful-loopback-shutdown.md
+++ b/docs/plans/0012-graceful-loopback-shutdown.md
@@ -1,0 +1,865 @@
+# Plan: Graceful Loopback Shutdown
+
+**Status:** Proposed
+**Issue:** #81
+**Related ADRs:** None (new feature)
+
+## Overview
+
+Enable graceful shutdown for pipelines with loopbacks without heuristics. Uses reference counting to detect when the pipeline is drained, then closes loopback outputs to break the cycle.
+
+## Goals
+
+1. Deterministic shutdown without idle-time heuristics
+2. Works for all loopback topologies (simple, batch, group, chained)
+3. No API changes for plugin **users** (internal plugin code changes, but `plugin.Loopback(...)` calls unchanged)
+4. Components remain decoupled - Engine owns all tracking logic
+5. Minimal runtime overhead
+
+## Problem
+
+Loopback creates a circular dependency that deadlocks on shutdown:
+
+```
+                   ┌─────────────────────────────────────┐
+                   │                                     │
+                   ↓                                     │
+External Input → Merger → Router → Distributor → Loopback Output
+                                          │
+                                          └→ External Output
+```
+
+**Deadlock sequence:**
+1. Context cancelled
+2. Merger waits for all inputs to close
+3. Loopback input waits for Distributor output to close
+4. Distributor waits for Router to close
+5. Router waits for Merger to close
+6. **DEADLOCK**
+
+## Solution: Reference Counting with Engine Wrapping
+
+Track messages through the pipeline via channel wrappers. Components remain decoupled - only Engine knows about tracking.
+
+### Architecture
+
+```
+                      ┌──────────────────────────────────────────────────────────┐
+                      │                         Engine                            │
+                      │   ┌────────────────────────────────────────────────────┐  │
+                      │   │                 MessageTracker                      │  │
+                      │   │              (Enter / Exit / Drained)               │  │
+                      │   └────────────────────────────────────────────────────┘  │
+                      │          ▲                ▲                ▲              │
+                      │          │                │                │              │
+External ─► AddInput ─┼─► [wrap Enter] ─► Merger ─► Router ─► Distributor ───────┼─► AddOutput ─► [wrap Exit] ─► External
+                      │                              ▲                │           │
+                      │                              │                ▼           │
+Loopback ◄─ AddLoopbackInput ◄───────────────────────┴──── AddLoopbackOutput ◄───┘
+                      │          (no wrap)                      (no wrap)         │
+                      └──────────────────────────────────────────────────────────┘
+```
+
+### Counting Rules
+
+| Event | Action | Location |
+|-------|--------|----------|
+| Message enters from external input | `Enter()` | Engine input wrapper |
+| Message enters from external raw input | `Enter()` | Engine raw input wrapper |
+| Message exits to external output | `Exit()` | Engine output wrapper |
+| Message exits to external raw output | `Exit()` | Engine raw output wrapper |
+| Handler drops message (returns 0) | `Exit()` | Engine handler wrapper |
+| Handler multiplies message (returns N>1) | `Enter()` × (N-1) | Engine handler wrapper |
+| Handler returns error | `Exit()` | Engine handler wrapper |
+| Message goes to loopback | Nothing | Not wrapped |
+| Message returns from loopback | Nothing | Not wrapped |
+
+### Shutdown Sequence
+
+```
+t0    ctx.Cancel()
+t1    Engine calls tracker.Close() to signal no more external inputs
+t2    Wait for tracker.Drained() OR ShutdownTimeout
+t3    Close loopback outputs (breaks cycle)
+t4    Loopback inputs see closed channel
+t5    Merger completes
+t6    Pipeline drains naturally
+t7    Wrapper goroutines complete (tracked via WaitGroup)
+t8    Engine done channel closes
+```
+
+## API Design
+
+### Engine (public)
+
+```go
+// External - tracked
+func (e *Engine) AddInput(name string, matcher Matcher, ch <-chan *Message) (<-chan struct{}, error)
+func (e *Engine) AddRawInput(name string, matcher Matcher, ch <-chan *RawMessage) (<-chan struct{}, error)
+func (e *Engine) AddOutput(name string, matcher Matcher) (<-chan *Message, error)
+func (e *Engine) AddRawOutput(name string, matcher Matcher) (<-chan *RawMessage, error)
+
+// Loopback - not tracked, marked for shutdown coordination
+func (e *Engine) AddLoopbackInput(name string, matcher Matcher, ch <-chan *Message) (<-chan struct{}, error)
+func (e *Engine) AddLoopbackOutput(name string, matcher Matcher) (<-chan *Message, error)
+```
+
+### Distributor (internal)
+
+```go
+// Existing
+func (d *Distributor[T]) AddOutput(matcher func(T) bool) (<-chan T, error)
+
+// New
+func (d *Distributor[T]) AddLoopbackOutput(matcher func(T) bool) (<-chan T, error)
+func (d *Distributor[T]) CloseLoopbackOutputs()  // Idempotent, safe to call multiple times
+```
+
+### MessageTracker (new, internal)
+
+```go
+// MessageTracker tracks in-flight messages for graceful shutdown.
+// Enter() increments count, Exit() decrements. Drained() closes when
+// count reaches zero AND Close() has been called.
+type MessageTracker struct {
+    inFlight atomic.Int64
+    closed   atomic.Bool
+    drained  chan struct{}
+    once     sync.Once
+}
+
+func NewMessageTracker() *MessageTracker
+func (t *MessageTracker) Enter()                    // Increment in-flight count
+func (t *MessageTracker) Exit()                     // Decrement; signal drained if zero and closed
+func (t *MessageTracker) Close()                    // Signal no more Enter() calls expected
+func (t *MessageTracker) Drained() <-chan struct{}  // Closed when count=0 and Close() called
+func (t *MessageTracker) InFlight() int64           // Current count (for debugging/metrics)
+```
+
+**Key behavior:**
+- `Drained()` only closes when BOTH conditions met: `Close()` called AND `inFlight == 0`
+- This handles the edge case where no messages ever enter (count stays 0)
+
+## Analysis
+
+### Goals Verification
+
+| Goal | Status | Notes |
+|------|--------|-------|
+| Deterministic shutdown without heuristics | ✅ | Reference counting is deterministic |
+| Works for all loopback topologies | ✅ | Tests cover simple, batch, group, chained |
+| No API changes for plugin users | ✅ | `plugin.Loopback(...)` signature unchanged |
+| Components remain decoupled | ✅ | Engine owns all tracking via wrappers |
+| Minimal runtime overhead | ✅ | Benchmarks validate <5% overhead target |
+
+### Edge Cases Coverage
+
+| Edge Case | Covered | Test |
+|-----------|---------|------|
+| Handler returns 0 messages | ✅ | `TestTrackedHandler_Drop` |
+| Handler returns N > 1 messages | ✅ | `TestTrackedHandler_Multiply` |
+| Handler returns error | ✅ | `TestTrackedHandler_Error` |
+| No external inputs (loopback only) | ✅ | `TestEngine_GracefulShutdown_NoExternalInputs` |
+| No loopbacks (baseline) | ✅ | `TestEngine_ShutdownWithoutLoopback` |
+| No messages sent before shutdown | ✅ | `TestEngine_GracefulShutdown_NoMessages` |
+| Multiple loopbacks | ✅ | `TestEngine_GracefulShutdown_MultipleLoopbacks` |
+| Chained loopbacks | ✅ | `TestEngine_GracefulShutdown_ChainedLoopbacks` |
+| Shutdown before Start() | ✅ | `TestEngine_ShutdownBeforeStart` |
+| AddLoopbackOutput after Start() | ✅ | `TestDistributor_AddLoopbackOutput_AfterStart` |
+| CloseLoopbackOutputs called twice | ✅ | `TestDistributor_CloseLoopbackOutputs_Idempotent` |
+| Raw inputs (AddRawInput) | ✅ | `TestEngine_GracefulShutdown_RawInput` |
+| Raw outputs (AddRawOutput) | ✅ | `TestEngine_GracefulShutdown_RawOutput` |
+| Wrapper goroutine cleanup | ✅ | `TestEngine_WrapperGoroutineCleanup` |
+| Context cancelled before any message | ✅ | `TestEngine_GracefulShutdown_ImmediateCancel` |
+| Infinite loop handler | ✅ | `TestEngine_GracefulShutdown_Timeout` |
+| ProcessLoopback with transformation | ✅ | `TestEngine_GracefulShutdown_ProcessLoopback` |
+
+### Convention Compliance
+
+| Convention | Status | Notes |
+|------------|--------|-------|
+| Config struct for constructors | ✅ | MessageTracker uses simple constructor (no config needed) |
+| Direct parameters for methods | ✅ | Enter(), Exit(), Close() have no parameters |
+| Error wrapping | N/A | No errors returned from tracker |
+| Godoc standards | ✅ | Included in API design section |
+| Test naming | ✅ | Follows `TestType_Method_Scenario` pattern |
+| Plan structure | ✅ | Follows planning.md template |
+
+### Idiomatic Go Verification
+
+| Aspect | Status | Notes |
+|--------|--------|-------|
+| Context propagation | ✅ | Uses existing ctx pattern from Engine |
+| Channel closure for completion | ✅ | Drained() returns receive-only channel |
+| WaitGroup for goroutine sync | ✅ | Engine tracks wrapper goroutines |
+| Atomic for counters | ✅ | Uses atomic.Int64, atomic.Bool |
+| sync.Once for one-time close | ✅ | Prevents double-close of drained channel |
+
+## Testing Strategy
+
+Tests must be written **before** implementation to establish baseline behavior and detect regressions.
+
+### Phase 1: Baseline Tests (Pre-Implementation)
+
+Establish current behavior and performance baselines.
+
+#### 1.1 Shutdown Behavior Tests
+
+Create `message/engine_shutdown_test.go`:
+
+```go
+func TestEngine_ShutdownWithoutLoopback(t *testing.T)
+    // Baseline: Engine without loopback shuts down cleanly
+    // Measures: shutdown latency, message delivery guarantee
+
+func TestEngine_ShutdownWithLoopback_CurrentBehavior(t *testing.T)
+    // Documents current deadlock/timeout behavior
+    // Expected: Waits for ShutdownTimeout (slow)
+
+func TestEngine_LoopbackMessageDelivery(t *testing.T)
+    // Verifies all messages are delivered before shutdown
+    // Baseline for message loss detection
+```
+
+#### 1.2 Performance Benchmarks
+
+Create `message/engine_bench_test.go`:
+
+```go
+func BenchmarkEngine_Throughput_NoLoopback(b *testing.B)
+    // Baseline throughput without loopback
+    // Measures: messages/second
+
+func BenchmarkEngine_Throughput_WithLoopback(b *testing.B)
+    // Baseline throughput with loopback
+    // Measures: messages/second
+
+func BenchmarkEngine_ShutdownLatency_NoLoopback(b *testing.B)
+    // Baseline shutdown time without loopback
+    // Measures: time from cancel to done
+
+func BenchmarkEngine_ShutdownLatency_WithLoopback(b *testing.B)
+    // Current shutdown time (expect: ~ShutdownTimeout)
+    // Measures: time from cancel to done
+
+func BenchmarkEngine_MessageOverhead(b *testing.B)
+    // Baseline per-message overhead
+    // Measures: allocations, CPU time per message
+```
+
+#### 1.3 Component Benchmarks
+
+Create `pipe/distributor_bench_test.go`:
+
+```go
+func BenchmarkDistributor_Route(b *testing.B)
+    // Baseline routing performance
+
+func BenchmarkDistributor_Route_WithLoopbackCheck(b *testing.B)
+    // Simulates overhead of loopback output tracking
+```
+
+Create `pipe/tracker_bench_test.go`:
+
+```go
+func BenchmarkMessageTracker_EnterExit(b *testing.B)
+    // Atomic counter overhead
+
+func BenchmarkMessageTracker_EnterExit_Parallel(b *testing.B)
+    // Contention under high concurrency
+```
+
+### Phase 2: Implementation Tests
+
+Written alongside implementation, run against new code.
+
+#### 2.1 MessageTracker Unit Tests
+
+Create `pipe/tracker_test.go`:
+
+```go
+func TestMessageTracker_EnterExit(t *testing.T)
+    // Basic counting
+
+func TestMessageTracker_Drained_ClosesWhenZeroAndClosed(t *testing.T)
+    // Drained channel closes when count=0 AND Close() called
+
+func TestMessageTracker_Drained_NotClosedUntilClose(t *testing.T)
+    // Count at 0 but Close() not called - Drained stays open
+
+func TestMessageTracker_Drained_OnlyClosesOnce(t *testing.T)
+    // Multiple zero crossings don't panic
+
+func TestMessageTracker_Concurrent(t *testing.T)
+    // Race detector clean under concurrent access
+
+func TestMessageTracker_NegativeCount(t *testing.T)
+    // Count can go negative (multiply case), Drained still works
+
+func TestMessageTracker_CloseWithZeroCount(t *testing.T)
+    // Close() when count already 0 - Drained closes immediately
+
+func TestMessageTracker_CloseIdempotent(t *testing.T)
+    // Multiple Close() calls are safe
+```
+
+#### 2.2 Distributor Loopback Tests
+
+Add to `pipe/distributor_test.go`:
+
+```go
+func TestDistributor_AddLoopbackOutput(t *testing.T)
+    // Loopback output is tracked separately
+
+func TestDistributor_AddLoopbackOutput_AfterStart(t *testing.T)
+    // Can add loopback output after Distribute() called
+
+func TestDistributor_CloseLoopbackOutputs(t *testing.T)
+    // Only loopback outputs are closed
+
+func TestDistributor_CloseLoopbackOutputs_Idempotent(t *testing.T)
+    // Safe to call multiple times
+
+func TestDistributor_CloseLoopbackOutputs_WhileRouting(t *testing.T)
+    // Safe to call during active routing
+
+func TestDistributor_MixedOutputs(t *testing.T)
+    // External and loopback outputs work together
+```
+
+#### 2.3 Engine Integration Tests
+
+Add to `message/engine_shutdown_test.go`:
+
+```go
+func TestEngine_GracefulShutdown_SimpleLoopback(t *testing.T)
+    // Single loopback, fast shutdown
+
+func TestEngine_GracefulShutdown_BatchLoopback(t *testing.T)
+    // BatchLoopback drains correctly
+
+func TestEngine_GracefulShutdown_GroupLoopback(t *testing.T)
+    // GroupLoopback drains correctly
+
+func TestEngine_GracefulShutdown_ProcessLoopback(t *testing.T)
+    // ProcessLoopback with channel.Process transformation
+
+func TestEngine_GracefulShutdown_MultipleLoopbacks(t *testing.T)
+    // Multiple independent loopbacks
+
+func TestEngine_GracefulShutdown_ChainedLoopbacks(t *testing.T)
+    // L1 output feeds L2 input
+
+func TestEngine_GracefulShutdown_HandlerDropsMessages(t *testing.T)
+    // Handler returns 0 messages
+
+func TestEngine_GracefulShutdown_HandlerMultipliesMessages(t *testing.T)
+    // Handler returns N > 1 messages
+
+func TestEngine_GracefulShutdown_NoExternalInputs(t *testing.T)
+    // Only loopback inputs (edge case)
+
+func TestEngine_GracefulShutdown_NoMessages(t *testing.T)
+    // Shutdown before any messages sent
+
+func TestEngine_GracefulShutdown_ImmediateCancel(t *testing.T)
+    // Context cancelled immediately after Start()
+
+func TestEngine_GracefulShutdown_Timeout(t *testing.T)
+    // Infinite loop handler triggers timeout
+
+func TestEngine_GracefulShutdown_NoMessageLoss(t *testing.T)
+    // All in-flight messages delivered
+
+func TestEngine_GracefulShutdown_RawInput(t *testing.T)
+    // AddRawInput is tracked
+
+func TestEngine_GracefulShutdown_RawOutput(t *testing.T)
+    // AddRawOutput is tracked
+
+func TestEngine_ShutdownBeforeStart(t *testing.T)
+    // Cancel context before Start() - no panic
+
+func TestEngine_WrapperGoroutineCleanup(t *testing.T)
+    // No goroutine leaks after shutdown
+```
+
+#### 2.4 Handler Wrapper Tests
+
+Create `message/tracked_handler_test.go`:
+
+```go
+func TestTrackedHandler_OneToOne(t *testing.T)
+    // Handler returns 1 message - no count change
+
+func TestTrackedHandler_Drop(t *testing.T)
+    // Handler returns 0 - Exit() called
+
+func TestTrackedHandler_Multiply(t *testing.T)
+    // Handler returns N - Enter() called N-1 times
+
+func TestTrackedHandler_Error(t *testing.T)
+    // Handler returns error - Exit() called
+
+func TestTrackedHandler_PreservesEventType(t *testing.T)
+    // EventType() delegated to inner handler
+
+func TestTrackedHandler_PreservesNewInput(t *testing.T)
+    // NewInput() delegated to inner handler
+```
+
+### Phase 3: Performance Validation
+
+Run after implementation to verify overhead is acceptable.
+
+#### 3.1 Overhead Analysis
+
+```go
+func BenchmarkEngine_Throughput_WithTracking(b *testing.B)
+    // Compare to baseline - target: <5% overhead
+
+func BenchmarkEngine_ShutdownLatency_WithTracking(b *testing.B)
+    // Compare to baseline - target: <100ms for drained pipeline
+
+func BenchmarkEngine_ChannelWrapper_Overhead(b *testing.B)
+    // Measure wrapper goroutine overhead
+    // Compare: direct channel vs wrapped channel
+```
+
+#### 3.2 Acceptance Criteria
+
+| Metric | Baseline | Target | Acceptable |
+|--------|----------|--------|------------|
+| Throughput overhead | 0% | <2% | <5% |
+| Per-message allocations | 0 extra | 0 extra | 1 extra |
+| Shutdown latency (drained) | N/A | <50ms | <100ms |
+| Shutdown latency (timeout) | ShutdownTimeout | ShutdownTimeout | Same |
+
+### Phase 4: Stress Tests
+
+```go
+func TestEngine_Stress_HighThroughput(t *testing.T)
+    // 100k messages, verify no race conditions
+
+func TestEngine_Stress_RapidShutdown(t *testing.T)
+    // Start/stop cycles, verify no goroutine leaks
+
+func TestEngine_Stress_ConcurrentLoopbacks(t *testing.T)
+    // Multiple loopbacks under high load
+```
+
+## Implementation Plan
+
+### Task 1: Baseline Tests & Benchmarks
+
+**Goal:** Establish current behavior before changes.
+
+**Files:**
+- `message/engine_shutdown_test.go` - Shutdown behavior tests
+- `message/engine_bench_test.go` - Engine benchmarks
+- `pipe/distributor_bench_test.go` - Distributor benchmarks
+
+**Acceptance:**
+- [ ] All baseline tests pass
+- [ ] Benchmarks produce stable results
+- [ ] Current loopback shutdown behavior documented
+
+### Task 2: MessageTracker
+
+**Goal:** Implement standalone counter with Close() semantics.
+
+**Files:**
+- `pipe/tracker.go` - Implementation
+- `pipe/tracker_test.go` - Unit tests
+- `pipe/tracker_bench_test.go` - Benchmarks
+
+**Implementation:**
+
+```go
+// MessageTracker tracks in-flight messages for graceful shutdown.
+type MessageTracker struct {
+    inFlight atomic.Int64
+    closed   atomic.Bool
+    drained  chan struct{}
+    once     sync.Once
+}
+
+func NewMessageTracker() *MessageTracker {
+    return &MessageTracker{
+        drained: make(chan struct{}),
+    }
+}
+
+func (t *MessageTracker) Enter() {
+    t.inFlight.Add(1)
+}
+
+func (t *MessageTracker) Exit() {
+    if t.inFlight.Add(-1) == 0 && t.closed.Load() {
+        t.once.Do(func() { close(t.drained) })
+    }
+}
+
+func (t *MessageTracker) Close() {
+    if t.closed.CompareAndSwap(false, true) {
+        if t.inFlight.Load() == 0 {
+            t.once.Do(func() { close(t.drained) })
+        }
+    }
+}
+
+func (t *MessageTracker) Drained() <-chan struct{} {
+    return t.drained
+}
+
+func (t *MessageTracker) InFlight() int64 {
+    return t.inFlight.Load()
+}
+```
+
+**Acceptance:**
+- [ ] All unit tests pass
+- [ ] Race detector clean
+- [ ] Benchmark shows <10ns per Enter/Exit
+- [ ] Close() + zero count closes Drained() immediately
+
+### Task 3: Distributor Loopback Support
+
+**Goal:** Add loopback output tracking with idempotent close.
+
+**Files:**
+- `pipe/distributor.go` - Add methods
+- `pipe/distributor_test.go` - Add tests
+
+**Implementation:**
+
+```go
+type Distributor[T any] struct {
+    // ... existing fields ...
+    loopbackOutputs map[chan T]struct{}
+    loopbackClosed  bool
+}
+
+func (d *Distributor[T]) AddLoopbackOutput(matcher func(T) bool) (<-chan T, error) {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    if d.closed {
+        return nil, errors.New("distributor: closed")
+    }
+
+    ch := make(chan T, d.cfg.Buffer)
+    d.outputs = append(d.outputs, outputEntry[T]{ch: ch, matcher: matcher})
+
+    if d.loopbackOutputs == nil {
+        d.loopbackOutputs = make(map[chan T]struct{})
+    }
+    d.loopbackOutputs[ch] = struct{}{}
+
+    return ch, nil
+}
+
+func (d *Distributor[T]) CloseLoopbackOutputs() {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    if d.loopbackClosed {
+        return  // Idempotent
+    }
+    d.loopbackClosed = true
+
+    for ch := range d.loopbackOutputs {
+        close(ch)
+    }
+
+    // Remove from outputs slice to prevent double-close in normal shutdown
+    filtered := d.outputs[:0]
+    for _, out := range d.outputs {
+        if _, isLoopback := d.loopbackOutputs[out.ch]; !isLoopback {
+            filtered = append(filtered, out)
+        }
+    }
+    d.outputs = filtered
+    d.loopbackOutputs = nil
+}
+```
+
+**Acceptance:**
+- [ ] `AddLoopbackOutput` works before and after Distribute()
+- [ ] `CloseLoopbackOutputs` only closes loopback outputs
+- [ ] `CloseLoopbackOutputs` is idempotent
+- [ ] Existing tests still pass
+- [ ] No performance regression in routing benchmark
+
+### Task 4: Engine Channel Wrappers
+
+**Goal:** Wrap input/output channels for tracking with proper goroutine lifecycle.
+
+**Files:**
+- `message/engine.go` - Add wrapper methods
+- `message/tracking.go` - Wrapper implementations
+
+**Implementation:**
+
+```go
+type Engine struct {
+    // ... existing fields ...
+    tracker   *pipe.MessageTracker
+    wrapperWg sync.WaitGroup  // Track wrapper goroutines
+}
+
+func (e *Engine) wrapInputChannel(ch <-chan *Message) <-chan *Message {
+    out := make(chan *Message)
+    e.wrapperWg.Add(1)
+    go func() {
+        defer e.wrapperWg.Done()
+        defer close(out)
+        for msg := range ch {
+            e.tracker.Enter()
+            out <- msg
+        }
+    }()
+    return out
+}
+
+func (e *Engine) wrapOutputChannel(ch <-chan *Message) <-chan *Message {
+    out := make(chan *Message)
+    e.wrapperWg.Add(1)
+    go func() {
+        defer e.wrapperWg.Done()
+        defer close(out)
+        for msg := range ch {
+            e.tracker.Exit()
+            out <- msg
+        }
+    }()
+    return out
+}
+
+// AddLoopbackInput - no wrapping, direct to merger
+func (e *Engine) AddLoopbackInput(name string, matcher Matcher, ch <-chan *Message) (<-chan struct{}, error) {
+    e.cfg.Logger.Info("Adding loopback input", "input", name)
+    filtered := e.applyTypedInputMatcher(name, ch, matcher)
+    return e.merger.AddInput(filtered)
+}
+
+// AddLoopbackOutput - no wrapping, marked for shutdown
+func (e *Engine) AddLoopbackOutput(name string, matcher Matcher) (<-chan *Message, error) {
+    e.cfg.Logger.Info("Adding loopback output", "output", name)
+    return e.distributor.AddLoopbackOutput(func(msg *Message) bool {
+        return matcher == nil || matcher.Match(msg.Attributes)
+    })
+}
+```
+
+**Acceptance:**
+- [ ] External channels are wrapped with Enter/Exit
+- [ ] Loopback channels are not wrapped
+- [ ] Raw input/output channels are wrapped
+- [ ] Wrapper goroutines tracked via WaitGroup
+- [ ] No goroutine leaks (verified via test)
+
+### Task 5: Engine Handler Wrapper
+
+**Goal:** Wrap handlers for drop/multiply tracking.
+
+**Files:**
+- `message/tracked_handler.go` - Implementation
+- `message/tracked_handler_test.go` - Tests
+
+**Implementation:**
+
+```go
+// trackedHandler wraps a Handler to track message drops and multiplies.
+type trackedHandler struct {
+    inner   Handler
+    tracker *pipe.MessageTracker
+}
+
+func (h *trackedHandler) EventType() string {
+    return h.inner.EventType()
+}
+
+func (h *trackedHandler) NewInput() any {
+    return h.inner.NewInput()
+}
+
+func (h *trackedHandler) Handle(ctx context.Context, msg *Message) ([]*Message, error) {
+    results, err := h.inner.Handle(ctx, msg)
+    if err != nil {
+        h.tracker.Exit()  // Error = message consumed
+        return nil, err
+    }
+
+    switch len(results) {
+    case 0:
+        h.tracker.Exit()  // Dropped
+    case 1:
+        // 1:1 transform, no change
+    default:
+        for i := 1; i < len(results); i++ {
+            h.tracker.Enter()  // Multiplied
+        }
+    }
+    return results, nil
+}
+```
+
+**Acceptance:**
+- [ ] Drop detection works (Exit called)
+- [ ] Multiply detection works (Enter called N-1 times)
+- [ ] Error handling works (Exit called)
+- [ ] Handler interface fully preserved (EventType, NewInput)
+
+### Task 6: Engine Shutdown Orchestration
+
+**Goal:** Coordinate shutdown using tracker.
+
+**Files:**
+- `message/engine.go` - Update Start()
+
+**Implementation:**
+
+```go
+func (e *Engine) Start(ctx context.Context) (<-chan struct{}, error) {
+    // ... existing setup ...
+
+    // Shutdown orchestration
+    go func() {
+        <-ctx.Done()
+
+        // Signal no more external inputs expected
+        e.tracker.Close()
+
+        // Wait for pipeline to drain or timeout
+        if e.cfg.ShutdownTimeout > 0 {
+            select {
+            case <-e.tracker.Drained():
+                // Pipeline drained naturally
+            case <-time.After(e.cfg.ShutdownTimeout):
+                // Timeout - force close
+            }
+        } else {
+            <-e.tracker.Drained()
+        }
+
+        // Close loopback outputs to break cycle
+        e.distributor.CloseLoopbackOutputs()
+    }()
+
+    // ... start pipeline ...
+}
+```
+
+**Acceptance:**
+- [ ] Shutdown calls tracker.Close()
+- [ ] Shutdown waits for Drained() or timeout
+- [ ] Loopback outputs closed after drain
+- [ ] All integration tests pass
+
+### Task 7: Plugin Updates
+
+**Goal:** Update loopback plugins to use new API.
+
+**Files:**
+- `message/plugin/loopback.go` - Use AddLoopbackInput/Output
+
+**Implementation:**
+
+```go
+func Loopback(name string, matcher message.Matcher) message.Plugin {
+    return func(e *message.Engine) error {
+        out, err := e.AddLoopbackOutput(name, matcher)
+        if err != nil {
+            return fmt.Errorf("loopback output: %w", err)
+        }
+        _, err = e.AddLoopbackInput(name, nil, out)
+        if err != nil {
+            return fmt.Errorf("loopback input: %w", err)
+        }
+        return nil
+    }
+}
+
+func ProcessLoopback(...) message.Plugin {
+    return func(e *message.Engine) error {
+        out, err := e.AddLoopbackOutput(name, matcher)
+        if err != nil {
+            return fmt.Errorf("process loopback output: %w", err)
+        }
+        processed := channel.Process(out, handle)
+        _, err = e.AddLoopbackInput(name, nil, processed)
+        if err != nil {
+            return fmt.Errorf("process loopback input: %w", err)
+        }
+        return nil
+    }
+}
+
+// BatchLoopback and GroupLoopback follow same pattern
+```
+
+**Acceptance:**
+- [ ] All loopback plugin tests pass
+- [ ] No API change for plugin users (`plugin.Loopback(...)` unchanged)
+- [ ] ProcessLoopback with transformation works
+- [ ] BatchLoopback works
+- [ ] GroupLoopback works
+
+### Task 8: Performance Validation
+
+**Goal:** Verify overhead is acceptable.
+
+**Acceptance:**
+- [ ] Throughput overhead <5%
+- [ ] Per-message allocations: 0 extra (or 1 acceptable)
+- [ ] Shutdown latency <100ms for drained pipeline
+- [ ] All stress tests pass
+- [ ] No goroutine leaks under stress
+
+## Implementation Order
+
+```
+Task 1: Baseline Tests ◄── Must complete first
+    │
+    ▼
+Task 2: MessageTracker
+    │
+    ▼
+Task 3: Distributor Loopback
+    │
+    ├──────────────────┐
+    ▼                  ▼
+Task 4: Channel     Task 5: Handler
+Wrappers            Wrapper
+    │                  │
+    └────────┬─────────┘
+             ▼
+Task 6: Shutdown Orchestration
+             │
+             ▼
+Task 7: Plugin Updates
+             │
+             ▼
+Task 8: Performance Validation ◄── Must pass before merge
+```
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Wrapper goroutine overhead | Performance regression | Benchmark before/after; WaitGroup tracks cleanup |
+| Negative count edge cases | Drained never closes | Test multiply scenarios; Drained closes at 0 crossing when closed |
+| Race in CloseLoopbackOutputs | Panic or deadlock | Proper locking; idempotent implementation; stress test |
+| Handler wrapper breaks interface | Compilation errors | Test EventType/NewInput preservation |
+| Close() not called | Drained never closes | Engine always calls Close() on ctx.Done() |
+
+## Acceptance Criteria
+
+- [ ] All Phase 1 baseline tests pass (before implementation)
+- [ ] All Phase 2 implementation tests pass
+- [ ] All Phase 3 performance benchmarks meet targets
+- [ ] All Phase 4 stress tests pass
+- [ ] Race detector clean (`go test -race`)
+- [ ] No goroutine leaks
+- [ ] CHANGELOG updated

--- a/examples/07-graceful-loopback-shutdown/main.go
+++ b/examples/07-graceful-loopback-shutdown/main.go
@@ -1,0 +1,234 @@
+// Example: Graceful loopback shutdown with orchestrated multi-step pipeline.
+//
+// Demonstrates graceful shutdown of a pipeline with multiple loopback steps:
+// - Step 1: Order Received -> Validate Order (loopback)
+// - Step 2: Validate Order -> Reserve Inventory (loopback)
+// - Step 3: Reserve Inventory -> Process Payment (loopback)
+// - Step 4: Process Payment -> Ship Order (loopback)
+// - Step 5: Ship Order -> Order Completed (output)
+//
+// The engine tracks in-flight messages and waits for the pipeline to drain
+// before closing loopback outputs. This ensures all messages complete their
+// journey through the pipeline without deadlock.
+//
+// Run: go run ./examples/07-graceful-loopback-shutdown
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/fxsml/gopipe/message"
+	"github.com/fxsml/gopipe/message/plugin"
+	"github.com/google/uuid"
+)
+
+// Order flow events
+type OrderReceived struct {
+	OrderID string  `json:"order_id"`
+	Amount  float64 `json:"amount"`
+}
+
+type OrderValidated struct {
+	OrderID string `json:"order_id"`
+	Valid   bool   `json:"valid"`
+}
+
+type InventoryReserved struct {
+	OrderID   string `json:"order_id"`
+	Reserved  bool   `json:"reserved"`
+	Warehouse string `json:"warehouse"`
+}
+
+type PaymentProcessed struct {
+	OrderID       string `json:"order_id"`
+	Paid          bool   `json:"paid"`
+	TransactionID string `json:"transaction_id"`
+}
+
+type OrderShipped struct {
+	OrderID    string `json:"order_id"`
+	TrackingID string `json:"tracking_id"`
+}
+
+type OrderCompleted struct {
+	OrderID    string `json:"order_id"`
+	Status     string `json:"status"`
+	TrackingID string `json:"tracking_id"`
+}
+
+// typeMatcher matches messages by CloudEvents type attribute.
+type typeMatcher struct {
+	pattern string
+}
+
+func (m *typeMatcher) Match(attrs message.Attributes) bool {
+	t, _ := attrs["type"].(string)
+	return t == m.pattern
+}
+
+func main() {
+	// Create engine with a shutdown timeout to ensure graceful drain
+	engine := message.NewEngine(message.EngineConfig{
+		Marshaler:       message.NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second, // Wait up to 5s for pipeline to drain
+	})
+
+	// Step 1: Order Received -> Order Validated
+	engine.AddHandler("validate-order", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd OrderReceived) ([]OrderValidated, error) {
+			fmt.Printf("[Step 1] Validating order %s (amount: $%.2f)\n", cmd.OrderID, cmd.Amount)
+			return []OrderValidated{{
+				OrderID: cmd.OrderID,
+				Valid:   cmd.Amount > 0,
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/orders", Naming: message.KebabNaming},
+	))
+
+	// Step 2: Order Validated -> Inventory Reserved
+	engine.AddHandler("reserve-inventory", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd OrderValidated) ([]InventoryReserved, error) {
+			fmt.Printf("[Step 2] Reserving inventory for order %s\n", cmd.OrderID)
+			if !cmd.Valid {
+				return nil, fmt.Errorf("invalid order")
+			}
+			return []InventoryReserved{{
+				OrderID:   cmd.OrderID,
+				Reserved:  true,
+				Warehouse: "WH-NYC",
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/inventory", Naming: message.KebabNaming},
+	))
+
+	// Step 3: Inventory Reserved -> Payment Processed
+	engine.AddHandler("process-payment", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd InventoryReserved) ([]PaymentProcessed, error) {
+			fmt.Printf("[Step 3] Processing payment for order %s (warehouse: %s)\n", cmd.OrderID, cmd.Warehouse)
+			if !cmd.Reserved {
+				return nil, fmt.Errorf("inventory not reserved")
+			}
+			return []PaymentProcessed{{
+				OrderID:       cmd.OrderID,
+				Paid:          true,
+				TransactionID: "TXN-" + uuid.NewString()[:8],
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/payments", Naming: message.KebabNaming},
+	))
+
+	// Step 4: Payment Processed -> Order Shipped
+	engine.AddHandler("ship-order", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd PaymentProcessed) ([]OrderShipped, error) {
+			fmt.Printf("[Step 4] Shipping order %s (txn: %s)\n", cmd.OrderID, cmd.TransactionID)
+			if !cmd.Paid {
+				return nil, fmt.Errorf("payment not completed")
+			}
+			return []OrderShipped{{
+				OrderID:    cmd.OrderID,
+				TrackingID: "TRACK-" + uuid.NewString()[:8],
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/shipping", Naming: message.KebabNaming},
+	))
+
+	// Step 5: Order Shipped -> Order Completed
+	engine.AddHandler("complete-order", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd OrderShipped) ([]OrderCompleted, error) {
+			fmt.Printf("[Step 5] Completing order %s (tracking: %s)\n", cmd.OrderID, cmd.TrackingID)
+			return []OrderCompleted{{
+				OrderID:    cmd.OrderID,
+				Status:     "completed",
+				TrackingID: cmd.TrackingID,
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/orders", Naming: message.KebabNaming},
+	))
+
+	// Configure loopbacks: each intermediate step loops back to continue the pipeline
+	// Loopback 1: OrderValidated -> back to engine (for Step 2)
+	engine.AddPlugin(plugin.Loopback("validate-loop", &typeMatcher{pattern: "order.validated"}))
+
+	// Loopback 2: InventoryReserved -> back to engine (for Step 3)
+	engine.AddPlugin(plugin.Loopback("inventory-loop", &typeMatcher{pattern: "inventory.reserved"}))
+
+	// Loopback 3: PaymentProcessed -> back to engine (for Step 4)
+	engine.AddPlugin(plugin.Loopback("payment-loop", &typeMatcher{pattern: "payment.processed"}))
+
+	// Loopback 4: OrderShipped -> back to engine (for Step 5)
+	engine.AddPlugin(plugin.Loopback("shipping-loop", &typeMatcher{pattern: "order.shipped"}))
+
+	// External input for orders
+	input := make(chan *message.RawMessage, 10)
+	engine.AddRawInput("orders", nil, input)
+
+	// External output for completed orders
+	output, _ := engine.AddRawOutput("completed", &typeMatcher{pattern: "order.completed"})
+
+	// Start engine
+	ctx, cancel := context.WithCancel(context.Background())
+	done, err := engine.Start(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("=== Starting Order Processing Pipeline ===")
+	fmt.Println()
+
+	// Process multiple orders
+	orders := []OrderReceived{
+		{OrderID: "ORD-001", Amount: 99.99},
+		{OrderID: "ORD-002", Amount: 149.50},
+		{OrderID: "ORD-003", Amount: 75.00},
+	}
+
+	for _, order := range orders {
+		data, _ := json.Marshal(order)
+		input <- message.NewRaw(data, message.Attributes{
+			message.AttrSpecVersion: "1.0",
+			message.AttrType:        "order.received",
+			message.AttrSource:      "/external",
+			message.AttrID:          uuid.NewString(),
+		}, nil)
+	}
+
+	// Collect completed orders
+	fmt.Println()
+	fmt.Println("=== Completed Orders ===")
+	for i := 0; i < len(orders); i++ {
+		select {
+		case result := <-output:
+			var completed OrderCompleted
+			json.Unmarshal(result.Data, &completed)
+			fmt.Printf("Order %s completed with tracking %s\n", completed.OrderID, completed.TrackingID)
+		case <-time.After(5 * time.Second):
+			log.Fatal("timeout waiting for completed order")
+		}
+	}
+
+	// Graceful shutdown demonstration
+	fmt.Println()
+	fmt.Println("=== Initiating Graceful Shutdown ===")
+
+	// Close input first (best practice)
+	close(input)
+
+	// Cancel context - engine will:
+	// 1. Signal tracker that no more external inputs are expected
+	// 2. Wait for all in-flight messages to drain through loopbacks
+	// 3. Close loopback outputs to break cycles
+	// 4. Complete shutdown cleanly
+	cancel()
+
+	// Wait for engine to stop
+	select {
+	case <-done:
+		fmt.Println("Engine shut down gracefully")
+	case <-time.After(10 * time.Second):
+		log.Fatal("shutdown timeout")
+	}
+}

--- a/message/engine_bench_test.go
+++ b/message/engine_bench_test.go
@@ -1,0 +1,383 @@
+package message
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fxsml/gopipe/channel"
+)
+
+// Benchmark types
+type BenchCommand struct {
+	ID int `json:"id"`
+}
+
+type BenchEvent struct {
+	ID   int `json:"id"`
+	Step int `json:"step"`
+}
+
+type BenchFinalEvent struct {
+	ID int `json:"id"`
+}
+
+type benchMatcher struct {
+	pattern string
+}
+
+func (m *benchMatcher) Match(attrs Attributes) bool {
+	t, _ := attrs["type"].(string)
+	return t == m.pattern
+}
+
+// silentLogger suppresses all log output during benchmarks
+type silentLogger struct{}
+
+func (silentLogger) Debug(msg string, args ...any) {}
+func (silentLogger) Info(msg string, args ...any)  {}
+func (silentLogger) Warn(msg string, args ...any)  {}
+func (silentLogger) Error(msg string, args ...any) {}
+
+// BenchmarkEngine_Loopback_Throughput measures message throughput with a single loopback.
+func BenchmarkEngine_Loopback_Throughput(b *testing.B) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+		BufferSize:      1000,
+		Logger:          silentLogger{},
+	})
+
+	// Step 1: Command -> Event
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchCommand) ([]BenchEvent, error) {
+			return []BenchEvent{{ID: cmd.ID, Step: 1}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	// Step 2: Event -> Final
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchEvent) ([]BenchFinalEvent, error) {
+			return []BenchFinalEvent{{ID: cmd.ID}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	// Loopback
+	loopOut, _ := engine.AddLoopbackOutput("loop", &benchMatcher{pattern: "bench.event"})
+	_, _ = engine.AddLoopbackInput("loop", nil, loopOut)
+
+	input := make(chan *RawMessage, 1000)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &benchMatcher{pattern: "bench.final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Prepare messages
+	msgs := make([]*RawMessage, b.N)
+	for i := 0; i < b.N; i++ {
+		data, _ := json.Marshal(BenchCommand{ID: i})
+		msgs[i] = NewRaw(data, Attributes{"type": "bench.command"}, nil)
+	}
+
+	b.ResetTimer()
+
+	// Send all messages
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, msg := range msgs {
+			input <- msg
+		}
+	}()
+
+	// Receive all messages
+	for i := 0; i < b.N; i++ {
+		<-output
+	}
+
+	b.StopTimer()
+
+	close(input)
+	cancel()
+	<-done
+	wg.Wait()
+}
+
+// BenchmarkEngine_Loopback_MultiStep measures throughput with chained loopbacks.
+func BenchmarkEngine_Loopback_MultiStep(b *testing.B) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+		BufferSize:      1000,
+		Logger:          silentLogger{},
+	})
+
+	// 4-step pipeline
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchCommand) ([]BenchEvent, error) {
+			return []BenchEvent{{ID: cmd.ID, Step: 1}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchEvent) ([]BenchEvent, error) {
+			return []BenchEvent{{ID: cmd.ID, Step: 2}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	_ = engine.AddHandler("step3", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchEvent) ([]BenchEvent, error) {
+			return []BenchEvent{{ID: cmd.ID, Step: 3}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	_ = engine.AddHandler("step4", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchEvent) ([]BenchFinalEvent, error) {
+			return []BenchFinalEvent{{ID: cmd.ID}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	// Create loopbacks using helper
+	addBenchLoopback := func(name, pattern string) {
+		out, _ := engine.AddLoopbackOutput(name, &benchMatcher{pattern: pattern})
+		_, _ = engine.AddLoopbackInput(name, nil, out)
+	}
+
+	addBenchLoopback("loop1", "bench.event")
+
+	input := make(chan *RawMessage, 1000)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &benchMatcher{pattern: "bench.final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Prepare messages
+	msgs := make([]*RawMessage, b.N)
+	for i := 0; i < b.N; i++ {
+		data, _ := json.Marshal(BenchCommand{ID: i})
+		msgs[i] = NewRaw(data, Attributes{"type": "bench.command"}, nil)
+	}
+
+	b.ResetTimer()
+
+	// Send all messages
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, msg := range msgs {
+			input <- msg
+		}
+	}()
+
+	// Receive all messages
+	for i := 0; i < b.N; i++ {
+		<-output
+	}
+
+	b.StopTimer()
+
+	close(input)
+	cancel()
+	<-done
+	wg.Wait()
+}
+
+// BenchmarkEngine_Loopback_ShutdownLatency measures time from cancel to done with loopbacks.
+func BenchmarkEngine_Loopback_ShutdownLatency(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		engine := NewEngine(EngineConfig{
+			Marshaler:       NewJSONMarshaler(),
+			ShutdownTimeout: 5 * time.Second,
+			BufferSize:      100,
+			Logger:          silentLogger{},
+		})
+
+		_ = engine.AddHandler("step1", nil, NewCommandHandler(
+			func(ctx context.Context, cmd BenchCommand) ([]BenchEvent, error) {
+				return []BenchEvent{{ID: cmd.ID, Step: 1}}, nil
+			},
+			CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+		))
+
+		_ = engine.AddHandler("step2", nil, NewCommandHandler(
+			func(ctx context.Context, cmd BenchEvent) ([]BenchFinalEvent, error) {
+				return []BenchFinalEvent{{ID: cmd.ID}}, nil
+			},
+			CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+		))
+
+		loopOut, _ := engine.AddLoopbackOutput("loop", &benchMatcher{pattern: "bench.event"})
+		_, _ = engine.AddLoopbackInput("loop", nil, loopOut)
+
+		input := make(chan *RawMessage, 100)
+		_, _ = engine.AddRawInput("input", nil, input)
+
+		output, _ := engine.AddRawOutput("output", &benchMatcher{pattern: "bench.final.event"})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done, _ := engine.Start(ctx)
+
+		// Send some messages
+		for j := 0; j < 100; j++ {
+			data, _ := json.Marshal(BenchCommand{ID: j})
+			input <- NewRaw(data, Attributes{"type": "bench.command"}, nil)
+		}
+
+		// Consume outputs
+		for j := 0; j < 100; j++ {
+			<-output
+		}
+
+		// Measure shutdown
+		close(input)
+		b.StartTimer()
+		cancel()
+		<-done
+		b.StopTimer()
+	}
+}
+
+// BenchmarkEngine_Loopback_ProcessLoopback measures throughput with transformation.
+func BenchmarkEngine_Loopback_ProcessLoopback(b *testing.B) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+		BufferSize:      1000,
+		Logger:          silentLogger{},
+	})
+
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchCommand) ([]BenchEvent, error) {
+			return []BenchEvent{{ID: cmd.ID, Step: 1}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchFinalEvent) ([]BenchFinalEvent, error) {
+			return []BenchFinalEvent{cmd}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	// ProcessLoopback with transformation
+	loopOut, _ := engine.AddLoopbackOutput("loop", &benchMatcher{pattern: "bench.event"})
+	processed := channel.Process(loopOut, func(msg *Message) []*Message {
+		event := msg.Data.(BenchEvent)
+		return []*Message{{
+			Data:       BenchFinalEvent{ID: event.ID},
+			Attributes: Attributes{"type": "bench.final.event"},
+		}}
+	})
+	_, _ = engine.AddLoopbackInput("loop", nil, processed)
+
+	input := make(chan *RawMessage, 1000)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &benchMatcher{pattern: "bench.final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Prepare messages
+	msgs := make([]*RawMessage, b.N)
+	for i := 0; i < b.N; i++ {
+		data, _ := json.Marshal(BenchCommand{ID: i})
+		msgs[i] = NewRaw(data, Attributes{"type": "bench.command"}, nil)
+	}
+
+	b.ResetTimer()
+
+	// Send all messages
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, msg := range msgs {
+			input <- msg
+		}
+	}()
+
+	// Receive all messages
+	for i := 0; i < b.N; i++ {
+		<-output
+	}
+
+	b.StopTimer()
+
+	close(input)
+	cancel()
+	<-done
+	wg.Wait()
+}
+
+// BenchmarkEngine_NoLoopback_Baseline measures throughput without loopback for comparison.
+func BenchmarkEngine_NoLoopback_Baseline(b *testing.B) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+		BufferSize:      1000,
+		Logger:          silentLogger{},
+	})
+
+	// Single handler, no loopback
+	_ = engine.AddHandler("handler", nil, NewCommandHandler(
+		func(ctx context.Context, cmd BenchCommand) ([]BenchFinalEvent, error) {
+			return []BenchFinalEvent{{ID: cmd.ID}}, nil
+		},
+		CommandHandlerConfig{Source: "/bench", Naming: KebabNaming},
+	))
+
+	input := make(chan *RawMessage, 1000)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &benchMatcher{pattern: "bench.final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Prepare messages
+	msgs := make([]*RawMessage, b.N)
+	for i := 0; i < b.N; i++ {
+		data, _ := json.Marshal(BenchCommand{ID: i})
+		msgs[i] = NewRaw(data, Attributes{"type": "bench.command"}, nil)
+	}
+
+	b.ResetTimer()
+
+	// Send all messages
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, msg := range msgs {
+			input <- msg
+		}
+	}()
+
+	// Receive all messages
+	for i := 0; i < b.N; i++ {
+		<-output
+	}
+
+	b.StopTimer()
+
+	close(input)
+	cancel()
+	<-done
+	wg.Wait()
+}

--- a/message/engine_graceful_shutdown_test.go
+++ b/message/engine_graceful_shutdown_test.go
@@ -1,0 +1,618 @@
+package message
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fxsml/gopipe/channel"
+)
+
+// Test types for graceful shutdown tests
+type Step1Command struct {
+	ID string `json:"id"`
+}
+
+type Step2Event struct {
+	ID   string `json:"id"`
+	Step int    `json:"step"`
+}
+
+type Step3Event struct {
+	ID   string `json:"id"`
+	Step int    `json:"step"`
+}
+
+type Step4Event struct {
+	ID   string `json:"id"`
+	Step int    `json:"step"`
+}
+
+type FinalEvent struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// shutdownTypeMatcher for tests
+type shutdownTypeMatcher struct {
+	pattern string
+}
+
+func (m *shutdownTypeMatcher) Match(attrs Attributes) bool {
+	t, _ := attrs["type"].(string)
+	return t == m.pattern
+}
+
+// addLoopback is a test helper that creates a loopback (equivalent to plugin.Loopback)
+func addLoopback(e *Engine, name string, matcher Matcher) error {
+	out, err := e.AddLoopbackOutput(name, matcher)
+	if err != nil {
+		return err
+	}
+	_, err = e.AddLoopbackInput(name, nil, out)
+	return err
+}
+
+// addProcessLoopback is a test helper that creates a process loopback
+func addProcessLoopback(e *Engine, name string, matcher Matcher, handle func(*Message) []*Message) error {
+	out, err := e.AddLoopbackOutput(name, matcher)
+	if err != nil {
+		return err
+	}
+	processed := channel.Process(out, handle)
+	_, err = e.AddLoopbackInput(name, nil, processed)
+	return err
+}
+
+// TestEngine_GracefulShutdown_ChainedLoopbacks verifies that a multi-step pipeline
+// with chained loopbacks shuts down gracefully without dropping in-flight messages.
+func TestEngine_GracefulShutdown_ChainedLoopbacks(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+	})
+
+	var processedCount atomic.Int32
+
+	// Step 1: Command -> Step2Event
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]Step2Event, error) {
+			return []Step2Event{{ID: cmd.ID, Step: 2}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Step 2: Step2Event -> Step3Event
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step2Event) ([]Step3Event, error) {
+			return []Step3Event{{ID: cmd.ID, Step: 3}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Step 3: Step3Event -> Step4Event
+	_ = engine.AddHandler("step3", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step3Event) ([]Step4Event, error) {
+			return []Step4Event{{ID: cmd.ID, Step: 4}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Step 4: Step4Event -> FinalEvent
+	_ = engine.AddHandler("step4", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step4Event) ([]FinalEvent, error) {
+			processedCount.Add(1)
+			return []FinalEvent{{ID: cmd.ID, Status: "completed"}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Wire up loopbacks for each intermediate step
+	_ = addLoopback(engine, "loop2", &shutdownTypeMatcher{pattern: "step2.event"})
+	_ = addLoopback(engine, "loop3", &shutdownTypeMatcher{pattern: "step3.event"})
+	_ = addLoopback(engine, "loop4", &shutdownTypeMatcher{pattern: "step4.event"})
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, err := engine.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Send multiple messages
+	messageCount := 10
+	for i := 0; i < messageCount; i++ {
+		data, _ := json.Marshal(Step1Command{ID: string(rune('A' + i))})
+		input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+	}
+
+	// Collect all outputs
+	received := make(map[string]bool)
+	for i := 0; i < messageCount; i++ {
+		select {
+		case msg := <-output:
+			var event FinalEvent
+			_ = json.Unmarshal(msg.Data, &event)
+			received[event.ID] = true
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for message %d", i+1)
+		}
+	}
+
+	// Initiate graceful shutdown
+	close(input)
+	cancel()
+
+	// Wait for engine to stop
+	select {
+	case <-done:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Fatal("Engine did not shut down within timeout")
+	}
+
+	// Verify all messages were processed
+	if int(processedCount.Load()) != messageCount {
+		t.Errorf("Expected %d messages processed, got %d", messageCount, processedCount.Load())
+	}
+
+	// Verify all messages received
+	if len(received) != messageCount {
+		t.Errorf("Expected %d messages received, got %d", messageCount, len(received))
+	}
+}
+
+// TestEngine_GracefulShutdown_InFlightDuringCancel verifies that messages
+// in the middle of a multi-step pipeline complete their journey during shutdown.
+func TestEngine_GracefulShutdown_InFlightDuringCancel(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+	})
+
+	var step1Count, step2Count, step3Count atomic.Int32
+	step2Started := make(chan struct{})
+	step2Proceed := make(chan struct{})
+
+	// Step 1: Fast
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]Step2Event, error) {
+			step1Count.Add(1)
+			return []Step2Event{{ID: cmd.ID, Step: 2}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Step 2: Blocks until signaled (simulates slow processing)
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step2Event) ([]Step3Event, error) {
+			step2Count.Add(1)
+			select {
+			case step2Started <- struct{}{}:
+			default:
+			}
+			<-step2Proceed // Wait for signal to continue
+			return []Step3Event{{ID: cmd.ID, Step: 3}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Step 3: Final
+	_ = engine.AddHandler("step3", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step3Event) ([]FinalEvent, error) {
+			step3Count.Add(1)
+			return []FinalEvent{{ID: cmd.ID, Status: "done"}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	_ = addLoopback(engine, "loop2", &shutdownTypeMatcher{pattern: "step2.event"})
+	_ = addLoopback(engine, "loop3", &shutdownTypeMatcher{pattern: "step3.event"})
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Send one message
+	data, _ := json.Marshal(Step1Command{ID: "test"})
+	input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+
+	// Wait for message to reach step 2 (in-flight)
+	select {
+	case <-step2Started:
+		// Message is now in step 2
+	case <-time.After(time.Second):
+		t.Fatal("Message didn't reach step 2")
+	}
+
+	// Close input and cancel while message is in-flight
+	close(input)
+	cancel()
+
+	// Allow step 2 to complete
+	close(step2Proceed)
+
+	// Wait for output - message should complete its journey
+	select {
+	case <-output:
+		// Success - message completed
+	case <-time.After(5 * time.Second):
+		t.Fatal("In-flight message was dropped during shutdown")
+	}
+
+	// Wait for engine
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Engine didn't shut down")
+	}
+
+	// Verify message completed all steps
+	if step1Count.Load() != 1 || step2Count.Load() != 1 || step3Count.Load() != 1 {
+		t.Errorf("Message didn't complete all steps: step1=%d, step2=%d, step3=%d",
+			step1Count.Load(), step2Count.Load(), step3Count.Load())
+	}
+}
+
+// TestEngine_GracefulShutdown_HandlerDropsMessages verifies that dropped messages
+// (handler returns empty) are tracked correctly for graceful shutdown.
+func TestEngine_GracefulShutdown_HandlerDropsMessages(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	var droppedCount atomic.Int32
+
+	// Handler that drops every other message
+	_ = engine.AddHandler("filter", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]FinalEvent, error) {
+			if cmd.ID[0]%2 == 0 {
+				droppedCount.Add(1)
+				return nil, nil // Drop
+			}
+			return []FinalEvent{{ID: cmd.ID, Status: "kept"}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Send 10 messages (5 will be dropped)
+	for i := 0; i < 10; i++ {
+		data, _ := json.Marshal(Step1Command{ID: string(rune(i))})
+		input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+	}
+
+	// Collect kept messages
+	kept := 0
+	timeout := time.After(2 * time.Second)
+	for kept < 5 {
+		select {
+		case <-output:
+			kept++
+		case <-timeout:
+			t.Fatalf("Timeout: expected 5 kept messages, got %d", kept)
+		}
+	}
+
+	// Initiate shutdown
+	close(input)
+	cancel()
+
+	select {
+	case <-done:
+		// Success - shutdown completed despite dropped messages
+	case <-time.After(5 * time.Second):
+		t.Fatal("Engine didn't shut down - dropped messages may not be tracked correctly")
+	}
+
+	if droppedCount.Load() != 5 {
+		t.Errorf("Expected 5 dropped messages, got %d", droppedCount.Load())
+	}
+}
+
+// TestEngine_GracefulShutdown_HandlerMultipliesMessages verifies that multiplied
+// messages (handler returns N > 1) are tracked correctly for graceful shutdown.
+func TestEngine_GracefulShutdown_HandlerMultipliesMessages(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 2 * time.Second,
+	})
+
+	var outputCount atomic.Int32
+
+	// Handler that produces 3 outputs per input
+	_ = engine.AddHandler("fanout", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]FinalEvent, error) {
+			return []FinalEvent{
+				{ID: cmd.ID + "-a", Status: "copy-a"},
+				{ID: cmd.ID + "-b", Status: "copy-b"},
+				{ID: cmd.ID + "-c", Status: "copy-c"},
+			}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Send 5 messages (should produce 15 outputs)
+	for i := 0; i < 5; i++ {
+		data, _ := json.Marshal(Step1Command{ID: string(rune('A' + i))})
+		input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+	}
+
+	// Collect all outputs
+	timeout := time.After(2 * time.Second)
+	for outputCount.Load() < 15 {
+		select {
+		case <-output:
+			outputCount.Add(1)
+		case <-timeout:
+			t.Fatalf("Timeout: expected 15 outputs, got %d", outputCount.Load())
+		}
+	}
+
+	// Initiate shutdown
+	close(input)
+	cancel()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("Engine didn't shut down - multiplied messages may not be tracked correctly")
+	}
+
+	if outputCount.Load() != 15 {
+		t.Errorf("Expected 15 outputs, got %d", outputCount.Load())
+	}
+}
+
+// TestEngine_GracefulShutdown_NoMessages verifies shutdown works when no messages
+// were ever sent.
+func TestEngine_GracefulShutdown_NoMessages(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: time.Second,
+	})
+
+	_ = engine.AddHandler("handler", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]FinalEvent, error) {
+			return []FinalEvent{{ID: cmd.ID}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	_ = addLoopback(engine, "loop", &shutdownTypeMatcher{pattern: "final.event"})
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+	_, _ = engine.AddRawOutput("output", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Immediately shutdown without sending any messages
+	close(input)
+	cancel()
+
+	select {
+	case <-done:
+		// Success - should complete quickly
+	case <-time.After(2 * time.Second):
+		t.Fatal("Engine didn't shut down when no messages were sent")
+	}
+}
+
+// TestEngine_GracefulShutdown_ImmediateCancel verifies shutdown works when
+// context is cancelled immediately after Start().
+func TestEngine_GracefulShutdown_ImmediateCancel(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: time.Second,
+	})
+
+	_ = engine.AddHandler("handler", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]FinalEvent, error) {
+			return []FinalEvent{{ID: cmd.ID}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	_ = addLoopback(engine, "loop", &shutdownTypeMatcher{pattern: "final.event"})
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+	_, _ = engine.AddRawOutput("output", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Cancel immediately
+	cancel()
+	close(input)
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Engine didn't shut down on immediate cancel")
+	}
+}
+
+// TestEngine_GracefulShutdown_NoMessageLoss verifies that messages in-flight
+// are processed during graceful shutdown.
+func TestEngine_GracefulShutdown_NoMessageLoss(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 10 * time.Second,
+	})
+
+	var processedCount atomic.Int64
+
+	// Simple loopback pipeline
+	_ = engine.AddHandler("step1", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]Step2Event, error) {
+			return []Step2Event{{ID: cmd.ID, Step: 2}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	_ = engine.AddHandler("step2", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step2Event) ([]FinalEvent, error) {
+			processedCount.Add(1)
+			return []FinalEvent{{ID: cmd.ID, Status: "done"}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	_ = addLoopback(engine, "loop", &shutdownTypeMatcher{pattern: "step2.event"})
+
+	input := make(chan *RawMessage, 100)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Send messages - reduced count to make test more reliable under race detector
+	messageCount := 50
+	for i := 0; i < messageCount; i++ {
+		data, _ := json.Marshal(Step1Command{ID: string(rune('A' + i))})
+		input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+	}
+
+	// Wait for all messages to be received before shutdown
+	receivedCount := 0
+	for receivedCount < messageCount {
+		select {
+		case <-output:
+			receivedCount++
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for message %d", receivedCount+1)
+		}
+	}
+
+	// Now initiate shutdown - all messages have been processed
+	close(input)
+	cancel()
+
+	// Wait for engine to stop
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Engine didn't shut down")
+	}
+
+	// Verify counts match
+	if processedCount.Load() != int64(messageCount) {
+		t.Errorf("Message mismatch: processed=%d, expected=%d",
+			processedCount.Load(), messageCount)
+	}
+}
+
+// TestEngine_GracefulShutdown_ProcessLoopback verifies graceful shutdown
+// works with ProcessLoopback transformation.
+func TestEngine_GracefulShutdown_ProcessLoopback(t *testing.T) {
+	engine := NewEngine(EngineConfig{
+		Marshaler:       NewJSONMarshaler(),
+		ShutdownTimeout: 5 * time.Second,
+	})
+
+	var transformCount atomic.Int32
+
+	// Initial handler
+	_ = engine.AddHandler("initial", nil, NewCommandHandler(
+		func(ctx context.Context, cmd Step1Command) ([]Step2Event, error) {
+			return []Step2Event{{ID: cmd.ID, Step: 2}}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// Handler that receives transformed messages
+	_ = engine.AddHandler("final", nil, NewCommandHandler(
+		func(ctx context.Context, cmd FinalEvent) ([]FinalEvent, error) {
+			return []FinalEvent{cmd}, nil
+		},
+		CommandHandlerConfig{Source: "/test", Naming: KebabNaming},
+	))
+
+	// ProcessLoopback with transformation
+	_ = addProcessLoopback(engine,
+		"transform-loop",
+		&shutdownTypeMatcher{pattern: "step2.event"},
+		func(msg *Message) []*Message {
+			transformCount.Add(1)
+			event := msg.Data.(Step2Event)
+			return []*Message{{
+				Data:       FinalEvent{ID: event.ID, Status: "transformed"},
+				Attributes: Attributes{"type": "final.event"},
+			}}
+		},
+	)
+
+	input := make(chan *RawMessage, 10)
+	_, _ = engine.AddRawInput("input", nil, input)
+
+	output, _ := engine.AddRawOutput("output", &shutdownTypeMatcher{pattern: "final.event"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done, _ := engine.Start(ctx)
+
+	// Send messages
+	for i := 0; i < 5; i++ {
+		data, _ := json.Marshal(Step1Command{ID: string(rune('A' + i))})
+		input <- NewRaw(data, Attributes{"type": "step1.command"}, nil)
+	}
+
+	// Collect outputs
+	for i := 0; i < 5; i++ {
+		select {
+		case msg := <-output:
+			var event FinalEvent
+			_ = json.Unmarshal(msg.Data, &event)
+			if event.Status != "transformed" {
+				t.Errorf("Expected transformed status, got %s", event.Status)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timeout waiting for output %d", i+1)
+		}
+	}
+
+	close(input)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Engine didn't shut down")
+	}
+
+	if transformCount.Load() != 5 {
+		t.Errorf("Expected 5 transforms, got %d", transformCount.Load())
+	}
+}

--- a/message/go.mod
+++ b/message/go.mod
@@ -16,3 +16,5 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 )
+
+replace github.com/fxsml/gopipe/pipe => ../pipe

--- a/message/go.sum
+++ b/message/go.sum
@@ -5,8 +5,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxsml/gopipe/channel v0.11.0 h1:DnBDcOhJdm/2gfSYbZhr09PKhA1ZTtTbRQ2nkUCkLAg=
 github.com/fxsml/gopipe/channel v0.11.0/go.mod h1:KU0JFSXWGZnenOeWKWNU5CCfnfMWiKwtmjXh5bOS6r4=
-github.com/fxsml/gopipe/pipe v0.11.0 h1:+0hJHeI9f/14ewyChkEtdU8iabvOyQQlxko6XTJH5u4=
-github.com/fxsml/gopipe/pipe v0.11.0/go.mod h1:cAfAzBsKJjw4QRveZHVfxVX+No6VEfMrrUmK7MnW1vo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/message/router.go
+++ b/message/router.go
@@ -3,6 +3,9 @@ package message
 import (
 	"context"
 	"log/slog"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/fxsml/gopipe/pipe"
@@ -38,8 +41,8 @@ type Router struct {
 
 // RouterConfig configures the message router.
 type RouterConfig struct {
-	BufferSize   int // Output channel buffer size (default: 100)
-	Concurrency  int // Number of concurrent handler invocations (default: 1)
+	BufferSize   int          // Output channel buffer size (default: 100)
+	Concurrency  int          // Number of concurrent handler invocations (default: 1)
 	ErrorHandler ErrorHandler // Default: no-op (errors logged via Logger)
 	Logger       Logger       // Default: slog.Default()
 }
@@ -179,3 +182,63 @@ func (r *Router) process(ctx context.Context, msg *Message) ([]*Message, error) 
 
 // Verify Router implements InputRegistry.
 var _ InputRegistry = (*Router)(nil)
+
+// funcName extracts a readable name from a function.
+// For package-level functions, returns "package.Function" (e.g., "context.Background").
+// For closures, returns the factory function name (e.g., "factory" from "factory.func1").
+func funcName(f any) string {
+	name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+
+	// Strip generic type parameters [...] to handle closures from generic functions.
+	// Example: "pkg.GenericFunc[...].func1" -> "pkg.GenericFunc.func1"
+	if idx := strings.Index(name, "["); idx >= 0 {
+		if end := strings.LastIndex(name, "]"); end > idx {
+			name = name[:idx] + name[end+1:]
+		}
+	}
+
+	// Find package boundary (after last /)
+	// "github.com/user/repo/pkg.Func" -> "pkg.Func"
+	pkgPart := name
+	if slash := strings.LastIndex(name, "/"); slash >= 0 {
+		pkgPart = name[slash+1:]
+	}
+
+	if dot := strings.LastIndex(pkgPart, "."); dot >= 0 {
+		suffix := pkgPart[dot+1:]
+		if isClosureSuffix(suffix) {
+			// Closure: traverse up past any intermediate funcN to find the factory name
+			parent := pkgPart[:dot]
+			for {
+				dot2 := strings.LastIndex(parent, ".")
+				if dot2 < 0 {
+					// Reached the end; if still a closure suffix, return "custom"
+					if isClosureSuffix(parent) {
+						return "custom"
+					}
+					return parent
+				}
+				segment := parent[dot2+1:]
+				if !isClosureSuffix(segment) {
+					return segment
+				}
+				parent = parent[:dot2]
+			}
+		}
+		// Package-level function: return package.FunctionName
+		return pkgPart
+	}
+	return "custom"
+}
+
+// isClosureSuffix checks if a name segment is a closure indicator.
+// Go names closures as "func1", "func2", etc. or just numeric like "1", "2".
+func isClosureSuffix(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] >= '0' && s[0] <= '9' {
+		return true
+	}
+	return len(s) > 4 && s[:4] == "func" && s[4] >= '0' && s[4] <= '9'
+}

--- a/message/tracker.go
+++ b/message/tracker.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// messageTracker tracks in-flight messages for graceful shutdown.
+// enter() increments count, exit() decrements. drained() closes when
+// count reaches zero AND close() has been called.
+//
+// Thread-safe for concurrent use.
+type messageTracker struct {
+	count      atomic.Int64
+	closed     atomic.Bool
+	drainedCh  chan struct{}
+	once       sync.Once
+}
+
+func newMessageTracker() *messageTracker {
+	return &messageTracker{
+		drainedCh: make(chan struct{}),
+	}
+}
+
+func (t *messageTracker) enter() {
+	t.count.Add(1)
+}
+
+func (t *messageTracker) exit() {
+	if t.count.Add(-1) == 0 && t.closed.Load() {
+		t.once.Do(func() { close(t.drainedCh) })
+	}
+}
+
+func (t *messageTracker) close() {
+	if t.closed.CompareAndSwap(false, true) {
+		if t.count.Load() == 0 {
+			t.once.Do(func() { close(t.drainedCh) })
+		}
+	}
+}
+
+func (t *messageTracker) drained() <-chan struct{} {
+	return t.drainedCh
+}
+
+func (t *messageTracker) inFlight() int64 {
+	return t.count.Load()
+}

--- a/message/tracker_test.go
+++ b/message/tracker_test.go
@@ -1,0 +1,197 @@
+package message
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMessageTracker_EnterExit(t *testing.T) {
+	tracker := newMessageTracker()
+
+	tracker.enter()
+	if tracker.inFlight() != 1 {
+		t.Errorf("expected InFlight=1, got %d", tracker.inFlight())
+	}
+
+	tracker.enter()
+	if tracker.inFlight() != 2 {
+		t.Errorf("expected InFlight=2, got %d", tracker.inFlight())
+	}
+
+	tracker.exit()
+	if tracker.inFlight() != 1 {
+		t.Errorf("expected InFlight=1, got %d", tracker.inFlight())
+	}
+
+	tracker.exit()
+	if tracker.inFlight() != 0 {
+		t.Errorf("expected InFlight=0, got %d", tracker.inFlight())
+	}
+}
+
+func TestMessageTracker_Drained_ClosesWhenZeroAndClosed(t *testing.T) {
+	tracker := newMessageTracker()
+
+	tracker.enter()
+	tracker.enter()
+	tracker.exit()
+	tracker.exit()
+
+	// Count is zero but Close() not called yet
+	select {
+	case <-tracker.drained():
+		t.Fatal("Drained should not close before Close() is called")
+	default:
+		// Expected
+	}
+
+	tracker.close()
+
+	// Now Drained should be closed
+	select {
+	case <-tracker.drained():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Drained should close after Close() when count is zero")
+	}
+}
+
+func TestMessageTracker_Drained_NotClosedUntilClose(t *testing.T) {
+	tracker := newMessageTracker()
+
+	// Count is already zero, but Close() not called
+	select {
+	case <-tracker.drained():
+		t.Fatal("Drained should not close before Close() is called")
+	default:
+		// Expected
+	}
+}
+
+func TestMessageTracker_CloseWithZeroCount(t *testing.T) {
+	tracker := newMessageTracker()
+
+	// Close immediately with zero count
+	tracker.close()
+
+	select {
+	case <-tracker.drained():
+		// Expected - should close immediately
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Drained should close immediately when Close() called with zero count")
+	}
+}
+
+func TestMessageTracker_CloseIdempotent(t *testing.T) {
+	tracker := newMessageTracker()
+
+	tracker.close()
+	tracker.close() // Should not panic
+	tracker.close() // Should not panic
+
+	select {
+	case <-tracker.drained():
+		// Expected
+	default:
+		t.Fatal("Drained should be closed")
+	}
+}
+
+func TestMessageTracker_Concurrent(t *testing.T) {
+	tracker := newMessageTracker()
+	var wg sync.WaitGroup
+
+	// Concurrent Enter/Exit
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.enter()
+			time.Sleep(time.Millisecond)
+			tracker.exit()
+		}()
+	}
+
+	wg.Wait()
+
+	if tracker.inFlight() != 0 {
+		t.Errorf("expected InFlight=0 after concurrent operations, got %d", tracker.inFlight())
+	}
+
+	tracker.close()
+
+	select {
+	case <-tracker.drained():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Drained should close")
+	}
+}
+
+func TestMessageTracker_DrainedClosesOnExit(t *testing.T) {
+	tracker := newMessageTracker()
+
+	tracker.enter()
+	tracker.close()
+
+	// Drained should not close yet (count = 1)
+	select {
+	case <-tracker.drained():
+		t.Fatal("Drained should not close while count > 0")
+	default:
+		// Expected
+	}
+
+	tracker.exit()
+
+	// Now Drained should close (count = 0 and closed)
+	select {
+	case <-tracker.drained():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Drained should close when count reaches zero after Close()")
+	}
+}
+
+func TestMessageTracker_OnlyClosesOnce(t *testing.T) {
+	tracker := newMessageTracker()
+
+	// Multiple zero crossings should not panic
+	tracker.enter()
+	tracker.exit()
+	tracker.enter()
+	tracker.exit()
+	tracker.enter()
+	tracker.close()
+	tracker.exit()
+
+	// Should not panic - Drained is already closed
+	select {
+	case <-tracker.drained():
+		// Expected
+	default:
+		t.Fatal("Drained should be closed")
+	}
+}
+
+func TestMessageTracker_NegativeCount(t *testing.T) {
+	// This tests the multiply case where count can temporarily go below expected
+	tracker := newMessageTracker()
+
+	tracker.enter()  // 1
+	tracker.enter()  // 2
+	tracker.enter()  // 3 (handler multiplied)
+	tracker.exit()   // 2
+	tracker.exit()   // 1
+	tracker.exit()   // 0
+
+	tracker.close()
+
+	select {
+	case <-tracker.drained():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Drained should close")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `messageTracker` to coordinate shutdown of loopback cycles
- Track external messages on entry/exit to detect pipeline drain
- Close loopback outputs only after all in-flight messages have exited

Fixes #81

## Test plan

- [x] Unit tests for messageTracker
- [x] Integration tests for graceful shutdown scenarios
- [x] Benchmark tests for performance impact
- [x] Example demonstrating graceful shutdown

🤖 Generated with [Claude Code](https://claude.ai/code)