### PR TITLE
fix(message): default Marshaler to JSONMarshaler in EngineConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to gopipe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-01-19
+
+### Fixed
+
+- **message:** Default `Marshaler` to `JSONMarshaler` when not set in `EngineConfig` (fixes #85)
+  - Previously, omitting `Marshaler` caused a nil pointer panic when processing raw inputs
+  - `EngineConfig.parse()` now defaults to `NewJSONMarshaler()` like other config fields
+
 ## [0.13.2] - 2026-01-19
 
 ### Fixed

--- a/message/engine.go
+++ b/message/engine.go
@@ -35,6 +35,9 @@ type EngineConfig struct {
 }
 
 func (c EngineConfig) parse() EngineConfig {
+	if c.Marshaler == nil {
+		c.Marshaler = NewJSONMarshaler()
+	}
 	if c.ErrorHandler == nil {
 		c.ErrorHandler = func(msg *Message, err error) {}
 	}


### PR DESCRIPTION
## Summary

- Default `Marshaler` to `NewJSONMarshaler()` in `EngineConfig.parse()`
- Previously, omitting `Marshaler` caused a nil pointer panic when processing raw inputs

## Problem

When `EngineConfig.Marshaler` was not set, the engine panicked with a nil pointer dereference when processing incoming raw messages:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8d1ca4]

goroutine 58 [running]:
github.com/fxsml/gopipe/message.(*Engine).unmarshal.NewUnmarshalPipe.func2(...)
        .../message@v0.13.2/pipes.go:19
```

## Solution

`EngineConfig.parse()` already defaulted `ErrorHandler`, `Logger`, and `BufferSize`. This fix adds `Marshaler` to the list:

```go
if c.Marshaler == nil {
    c.Marshaler = NewJSONMarshaler()
}
```

## Test plan

- [x] Added `TestEngine_DefaultMarshaler` to verify the fix
- [x] All existing tests pass

Fixes #85