### PR TITLE
refactor(message): improve error logging and messages

### DIFF
--- a/message/cloudevents/publisher.go
+++ b/message/cloudevents/publisher.go
@@ -47,7 +47,8 @@ func NewPublisher(sender protocol.Sender, cfg PublisherConfig) *Publisher {
 		Concurrency: cfg.Concurrency,
 		ErrorHandler: func(in any, err error) {
 			raw, _ := in.(*message.RawMessage)
-			logger.Error("Publisher error",
+			logger.Error("Message send failed",
+				"component", "publisher",
 				"error", err,
 				"attributes", raw.Attributes)
 			if cfg.ErrorHandler != nil {

--- a/message/errors.go
+++ b/message/errors.go
@@ -9,12 +9,12 @@ var (
 	// ErrInputRejected is returned when a message is rejected by input matcher.
 	ErrInputRejected = errors.New("message rejected by input matcher")
 
-	// ErrNoHandler is returned when no handler exists for a CE type.
-	ErrNoHandler = errors.New("no handler for CE type")
+	// ErrNoHandler is returned when no handler exists for a message type.
+	ErrNoHandler = errors.New("no handler for message type")
 
 	// ErrHandlerRejected is returned when a message is rejected by handler matcher.
 	ErrHandlerRejected = errors.New("message rejected by handler matcher")
 
-	// ErrUnknownType is returned when unmarshaling a message with unknown CE type.
-	ErrUnknownType = errors.New("unknown CE type")
+	// ErrUnknownType is returned when unmarshaling a message with unknown type.
+	ErrUnknownType = errors.New("unknown message type")
 )


### PR DESCRIPTION
## Summary

- Add attributes to error logs in unmarshal and marshal ErrorHandlers for better debugging
- Rename "CE type" to "message type" in error messages for consistency

## Changes

### Error logging improvements

Unmarshal and Marshal ErrorHandlers now log message attributes (consistent with Router and Distributor):

```go
e.cfg.Logger.Error("Unmarshaling raw message failed",
    "error", err,
    "attributes", raw.Attributes)
```

### Error message naming

The message package doesn't use "CE" prefix elsewhere (`Type()` not `CEType()`, `Attributes` not `CEAttributes`), so error messages now use "message type":

| Before | After |
|--------|-------|
| `no handler for CE type` | `no handler for message type` |
| `unknown CE type` | `unknown message type` |

## Test plan

- [x] All existing tests pass