### PR TITLE
feat(message): add Recover middleware for panic recovery

### DIFF
--- a/message/middleware/recover.go
+++ b/message/middleware/recover.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/fxsml/gopipe/message"
+)
+
+// RecoveryError wraps a panic value with the stack trace.
+// This allows panics to be converted to regular errors and handled gracefully.
+type RecoveryError struct {
+	// PanicValue is the original value that was passed to panic().
+	PanicValue any
+	// StackTrace contains the full stack trace at the point of panic.
+	StackTrace string
+}
+
+func (e *RecoveryError) Error() string {
+	return fmt.Sprintf("panic recovered: %v", e.PanicValue)
+}
+
+// Recover wraps message processing with panic recovery.
+// Any panic that occurs during processing is caught and converted
+// into a RecoveryError with the stack trace captured.
+func Recover() message.Middleware {
+	return func(next message.ProcessFunc) message.ProcessFunc {
+		return func(ctx context.Context, msg *message.Message) (out []*message.Message, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = &RecoveryError{
+						PanicValue: r,
+						StackTrace: string(debug.Stack()),
+					}
+				}
+			}()
+			return next(ctx, msg)
+		}
+	}
+}

--- a/message/middleware/recover_test.go
+++ b/message/middleware/recover_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/fxsml/gopipe/message"
+)
+
+func TestRecoverSuccessfulProcessing(t *testing.T) {
+	processFunc := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+		return []*message.Message{msg}, nil
+	}
+	fn := Recover()(processFunc)
+
+	msg := message.New("test", nil, nil)
+	result, err := fn(context.Background(), msg)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("Expected len to be 1, got %d", len(result))
+	}
+	if result[0] != msg {
+		t.Errorf("Expected same message returned")
+	}
+}
+
+func TestRecoverProcessingWithPanic(t *testing.T) {
+	processFunc := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+		panic("test panic")
+	}
+	fn := Recover()(processFunc)
+
+	msg := message.New("test", nil, nil)
+	_, err := fn(context.Background(), msg)
+
+	if err == nil {
+		t.Error("Expected an error, got nil")
+		return
+	}
+
+	var recoveryErr *RecoveryError
+	if !errors.As(err, &recoveryErr) {
+		t.Errorf("Expected *RecoveryError, got %T", err)
+		return
+	}
+
+	if recoveryErr.PanicValue != "test panic" {
+		t.Errorf("Expected panic value 'test panic', got %v", recoveryErr.PanicValue)
+	}
+
+	if !strings.Contains(recoveryErr.StackTrace, "runtime/debug.Stack") {
+		t.Error("Expected stack trace to contain 'runtime/debug.Stack'")
+	}
+}
+
+func TestRecoverProcessingWithError(t *testing.T) {
+	expectedErr := errors.New("handler error")
+	processFunc := func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+		return nil, expectedErr
+	}
+	fn := Recover()(processFunc)
+
+	msg := message.New("test", nil, nil)
+	_, err := fn(context.Background(), msg)
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Expected %v, got %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Recover` middleware that wraps message processing with panic recovery
- Panics are caught and converted to `RecoveryError` with stack trace captured
- Includes tests for successful processing, panic recovery, and error passthrough

## Test plan
- [x] `TestRecoverSuccessfulProcessing` - verifies normal processing works
- [x] `TestRecoverProcessingWithPanic` - verifies panics are caught and converted to errors
- [x] `TestRecoverProcessingWithError` - verifies errors pass through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)