### PR TITLE
fix(message): consistent Merger error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to gopipe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-01-21
+
+### Fixed
+
+- **message:** Merger error logs now use consistent structured format (#92)
+  - Added custom ErrorHandler to Engine and Router Mergers
+  - Logs include `component`, `error`, and `attributes` fields
+  - Removes `[GOPIPE]` prefix and raw JSON dump from error messages
+
 ## [0.14.0] - 2026-01-21
 
 ### Added

--- a/message/router.go
+++ b/message/router.go
@@ -248,6 +248,14 @@ func (r *Router) pipeMultiPool(ctx context.Context, in <-chan *Message, fn Proce
 
 	merger := pipe.NewMerger[*Message](pipe.MergerConfig{
 		Buffer: r.bufferSize,
+		ErrorHandler: func(in any, err error) {
+			msg := in.(*Message)
+			r.logger.Warn("Message merge failed",
+				"component", "router",
+				"error", err,
+				"attributes", msg.Attributes)
+			r.errorHandler(msg, err)
+		},
 	})
 
 	// Wire: Distributor output(poolMatcher) → ProcessPipe(workers) → Merger input


### PR DESCRIPTION
## Summary

- Add custom ErrorHandler to Engine and Router Mergers for consistent structured logging
- Change Engine's Distributor component label from "distributor" to "engine"
- Logs now include `component`, `error`, and `attributes` fields instead of `[GOPIPE]` prefix with raw JSON

Fixes #92

## Test plan

- [x] All tests pass (`make test`)
- [x] Build succeeds (`go build ./message/...`)