### PR TITLE
fix(message): track fan-in/fan-out in loopback plugins for graceful shutdown

### DIFF
--- a/message/tracker.go
+++ b/message/tracker.go
@@ -6,8 +6,8 @@ import (
 )
 
 // messageTracker tracks in-flight messages for graceful shutdown.
-// enter() increments count, exit() decrements. drained() closes when
-// count reaches zero AND close() has been called.
+// enter(n) increments count by n, exit(n) decrements by n. drained() closes
+// when count reaches zero AND close() has been called.
 //
 // Thread-safe for concurrent use.
 type messageTracker struct {
@@ -23,12 +23,12 @@ func newMessageTracker() *messageTracker {
 	}
 }
 
-func (t *messageTracker) enter() {
-	t.count.Add(1)
+func (t *messageTracker) enter(n int64) {
+	t.count.Add(n)
 }
 
-func (t *messageTracker) exit() {
-	if t.count.Add(-1) == 0 && t.closed.Load() {
+func (t *messageTracker) exit(n int64) {
+	if t.count.Add(-n) <= 0 && t.closed.Load() {
 		t.once.Do(func() { close(t.drainedCh) })
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `AdjustInFlight(delta int)` method to Engine for loopback plugins to adjust in-flight message count
- Updates `BatchLoopback`, `GroupLoopback`, and `ProcessLoopback` to track fan-in/fan-out
- Updates tracker's `enter`/`exit` to accept batch counts for efficient operations
- Adds 4 graceful shutdown tests for loopback plugins
- Updates example 07 to demonstrate fan-in with BatchLoopback

## Test plan

- [x] All existing tests pass
- [x] New graceful shutdown tests verify tracker adjustment
- [x] Example 07 demonstrates shutdown completing in ~18µs instead of 5s timeout

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)