### PR TITLE
fix(pipe,message): graceful shutdown with no silent message loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to gopipe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-01-23
+
+### Fixed
+
+- **message:** Handler context no longer canceled during graceful shutdown
+  - Handlers now receive a separate context that only cancels when ShutdownTimeout fires
+  - In-flight handlers complete successfully instead of failing with "context canceled"
+  - App context cancellation signals shutdown but doesn't interrupt handler work
+- **message:** Distributor no longer hangs when output channels are full during shutdown
+  - Distributor now uses ShutdownTimeout to force-close after timeout
+  - Prevents engine from hanging indefinitely when raw output consumers are blocked
+- **message:** Router worker pools no longer hang during shutdown
+  - Router now propagates ShutdownTimeout to internal ProcessPipes, Distributor, and Merger
+  - Workers blocked on full output channels unblock after timeout
+- **pipe/message:** No silent message loss during shutdown timeout
+  - ProcessPipe, Merger, and Distributor now drain input channels after workers exit
+  - All buffered messages reported to ErrorHandler with `ErrShutdownDropped`
+  - Engine wrappers also drain and report dropped messages
+
 ## [0.15.0] - 2026-01-23
 
 ### Added

--- a/pipe/distributor.go
+++ b/pipe/distributor.go
@@ -100,6 +100,9 @@ func (d *Distributor[T]) Distribute(ctx context.Context, input <-chan T) (<-chan
 		for {
 			select {
 			case <-d.done:
+				drainChannel(input, func(msg T) {
+					d.cfg.ErrorHandler(msg, ErrShutdownDropped)
+				})
 				return
 			case msg, ok := <-input:
 				if !ok {


### PR DESCRIPTION
## Summary

- Handler context only cancels when ShutdownTimeout fires, not on app context cancel
- Router propagates ShutdownTimeout to internal components
- Distributor/Merger/ProcessPipe drain input channels on shutdown
- All dropped messages reported to ErrorHandler with `ErrShutdownDropped`
- Add `drainChannel[T]` helper for consistent drain behavior
- Engine wrappers drain and report dropped messages

## Test plan

- [x] All existing shutdown tests pass
- [x] `TestEngine_Shutdown_NoSilentMessageLoss` - verifies all messages accounted for
- [x] `TestProcessing_ShutdownDrainsInput` - verifies ProcessPipe drains
- [x] `TestMerger_ShutdownDrainsInput` - verifies Merger drains
- [x] `TestDistributor_ShutdownDrainsInput` - verifies Distributor drains

🤖 Generated with [Claude Code](https://claude.com/claude-code)