### PR TITLE
feat(pipe): add dynamic concurrency autoscaling

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -2,9 +2,10 @@
 
 ## Current
 
-| Plan | Title | Status |
-|------|-------|--------|
-| [0007](0007-cesql-pattern-matching.md) | CESQL Pattern Matching | Proposed |
+| Plan | Status | Description |
+|------|--------|-------------|
+| [0007](0007-cesql-pattern-matching.md) | Proposed | CESQL Pattern Matching |
+| [pipe-autoscaling](pipe-autoscaling.md) | In Progress | Dynamic worker pool |
 
 ## Agent Guidance
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,6 +6,7 @@
 |------|--------|-------------|
 | [0007](0007-cesql-pattern-matching.md) | Proposed | CESQL Pattern Matching |
 | [pipe-autoscaling](pipe-autoscaling.md) | In Progress | Dynamic worker pool |
+| [pipe-ordering](pipe-ordering.md) | Proposed | Preserved message ordering |
 
 ## Agent Guidance
 

--- a/docs/plans/pipe-autoscaling.md
+++ b/docs/plans/pipe-autoscaling.md
@@ -6,12 +6,6 @@
 
 Replace the static `Concurrency int` configuration with a dynamic autoscaling system that supports min/max bounds and automatically adjusts worker count based on load.
 
-## Current State
-
-- `pipe/processing.go`: `Config.Concurrency` is a static int (default 1)
-- Workers spawned once at startup: `wg.Add(cfg.Concurrency)` + `for range cfg.Concurrency`
-- No runtime adjustment of worker count
-
 ## Design Approach
 
 **Backpressure-based scaling** (validated against industry patterns):
@@ -30,41 +24,52 @@ Replace the static `Concurrency int` configuration with a dynamic autoscaling sy
 
 **Why not Watermill's approach?** Watermill relies on message broker partitions for parallelism. gopipe is a general-purpose pipeline library, so explicit worker management is more appropriate.
 
-## New Files
+## Implementation
+
+### File Structure
 
 ```
-pipe/internal/autoscale/
-├── pool.go       # Pool struct, worker management, Start/Stop
-├── scaler.go     # Scaling decision loop
-├── config.go     # Internal config with defaults
-└── pool_test.go  # Unit tests
+pipe/
+├── autoscale.go              # AutoscaleConfig type with parse() method
+├── processing.go             # Dispatcher + startStaticProcessing() + startAutoscaledProcessing()
+└── internal/autoscale/
+    ├── config.go             # Default constants only
+    ├── pool.go               # Pool struct, worker management, scaler loop
+    └── pool_test.go          # Unit tests
 ```
 
-## Configuration API
+### Configuration API
 
 ```go
-// In pipe/processing.go - add to Config struct
+// In pipe/processing.go
 type Config struct {
-    Concurrency int  // Static workers (ignored when Autoscale is set)
-
-    // NEW: Dynamic scaling config
-    Autoscale *AutoscaleConfig
-
+    Concurrency int              // Static workers (ignored when Autoscale is set)
+    Autoscale   *AutoscaleConfig // Dynamic scaling config
     // ... existing fields unchanged ...
 }
 
-// New type in pipe/autoscale.go (or inline in processing.go)
+// In pipe/autoscale.go
 type AutoscaleConfig struct {
     MinWorkers        int           // Default: 1
     MaxWorkers        int           // Default: runtime.NumCPU()
-    ScaleDownAfter    time.Duration // Idle duration before scale-down. Default: 30s
-    ScaleUpCooldown   time.Duration // Min time between scale-ups. Default: 5s
-    ScaleDownCooldown time.Duration // Min time between scale-downs. Default: 10s
-    CheckInterval     time.Duration // How often to evaluate. Default: 1s
+    ScaleDownAfter    time.Duration // Default: 30s
+    ScaleUpCooldown   time.Duration // Default: 5s
+    ScaleDownCooldown time.Duration // Default: 10s
+    CheckInterval     time.Duration // Default: 1s
 }
+
+var defaultAutoscaleConfig = AutoscaleConfig{
+    MinWorkers:        1,
+    ScaleDownAfter:    30 * time.Second,
+    ScaleUpCooldown:   5 * time.Second,
+    ScaleDownCooldown: 10 * time.Second,
+    CheckInterval:     1 * time.Second,
+}
+
+func (c AutoscaleConfig) parse() AutoscaleConfig { ... }
 ```
 
-## Usage Examples
+### Usage Examples
 
 ```go
 // Existing usage - unchanged (backward compatible)
@@ -79,106 +84,43 @@ p := pipe.NewProcessPipe(fn, pipe.Config{
 })
 ```
 
-## Implementation Steps
-
-### 1. Create internal autoscale package
-- `pipe/internal/autoscale/config.go`: Internal config struct with `parse()` method
-- `pipe/internal/autoscale/pool.go`: Pool struct managing workers map, spawn/stop logic
-
-### 2. Implement worker management
-- Worker struct with id, stopCh, lastActive, idle state
-- `spawnWorker()` / `stopWorker()` methods
-- Idle tracking: mark active when processing, idle when waiting
-
-### 3. Implement scaler loop
-- `runScaler()` goroutine with ticker at CheckInterval
-- Backpressure detection: scale up when `activeWorkers == totalWorkers` (all busy)
-- Idle detection: scale down when worker's `lastActive` exceeds `ScaleDownAfter`
-- Cooldown enforcement to prevent thrashing
-
-### 4. Integrate with startProcessing()
-- Check if `cfg.Autoscale != nil`
-- If yes, delegate to `startAutoscaledProcessing()`
-- If no, use existing static worker loop (unchanged)
-
-### 5. Add tests
-- Unit tests for pool scaling behavior
-- Integration tests with varying load patterns
-- Verify backward compatibility
-
-## Key Files to Modify
-
-| File | Change |
-|------|--------|
-| `pipe/processing.go` | Add `Autoscale *AutoscaleConfig` to Config, add `startAutoscaledProcessing()` |
-| `pipe/internal/autoscale/pool.go` | NEW: Pool implementation |
-| `pipe/internal/autoscale/scaler.go` | NEW: Scaling logic |
-| `pipe/internal/autoscale/config.go` | NEW: Config with defaults |
-
-## Load Detection (Pending Counter Approach)
-
-The pending counter approach detects backpressure by tracking active vs total workers:
+### Processing Dispatcher
 
 ```go
-type Pool struct {
-    mu            sync.Mutex
-    workers       map[int]*worker   // all spawned workers
-    totalWorkers  atomic.Int64      // count of spawned workers
-    activeWorkers atomic.Int64      // workers currently processing (not idle)
-}
+func startProcessing[In, Out any](...) <-chan Out {
+    cfg = cfg.parse()
 
-type worker struct {
-    id         int
-    lastActive time.Time     // last time worker finished processing
-    stopCh     chan struct{} // signal to stop this worker
-}
-```
-
-**Worker lifecycle:**
-```go
-func (p *Pool) runWorker(w *worker, in <-chan In, fn ProcessFunc) {
-    for {
-        select {
-        case <-w.stopCh:
-            return
-        case val, ok := <-in:
-            if !ok {
-                return
-            }
-            p.activeWorkers.Add(1)       // mark as busy
-            result, err := fn(ctx, val)
-            p.activeWorkers.Add(-1)      // mark as available
-
-            p.mu.Lock()
-            w.lastActive = time.Now()    // track for idle detection
-            p.mu.Unlock()
-
-            // ... handle result/error ...
-        }
+    if cfg.Autoscale != nil {
+        return startAutoscaledProcessing(ctx, in, fn, cfg)
     }
+    return startStaticProcessing(ctx, in, fn, cfg)
 }
 ```
 
-**Scale-up decision:**
-```go
-// If all workers are busy (activeWorkers == totalWorkers) for sustained period
-if p.activeWorkers.Load() >= p.totalWorkers.Load() &&
-   time.Since(lastScaleUp) >= cfg.ScaleUpCooldown &&
-   p.totalWorkers.Load() < cfg.MaxWorkers {
-    p.spawnWorker()
-}
-```
+### Internal Pool (pipe/internal/autoscale/pool.go)
 
-**Scale-down decision:**
 ```go
-// Find workers idle for too long
-for _, w := range p.workers {
-    if time.Since(w.lastActive) >= cfg.ScaleDownAfter &&
-       p.totalWorkers.Load() > cfg.MinWorkers {
-        close(w.stopCh)  // gracefully stop this worker
-        break  // scale down one at a time
-    }
+type PoolConfig struct {
+    MinWorkers, MaxWorkers        int
+    ScaleDownAfter                time.Duration
+    ScaleUpCooldown, ScaleDownCooldown time.Duration
+    CheckInterval                 time.Duration
 }
+
+type Pool[In, Out any] struct {
+    cfg           PoolConfig
+    fn            func(context.Context, In) ([]Out, error)
+    workers       map[int]*worker
+    totalWorkers  atomic.Int64
+    activeWorkers atomic.Int64
+    // ...
+}
+
+func NewPool[In, Out any](cfg PoolConfig, fn func(...), ...) *Pool[In, Out]
+func (p *Pool) Start(ctx context.Context, in <-chan In, bufferSize int) <-chan Out
+func (p *Pool) Stop()
+func (p *Pool) TotalWorkers() int64
+func (p *Pool) ActiveWorkers() int64
 ```
 
 ## Default Values (0 = auto)
@@ -192,23 +134,22 @@ for _, w := range p.workers {
 | ScaleDownAfter | use default | 30s |
 | CheckInterval | use default | 1s |
 
-```go
-func (c AutoscaleConfig) parse() AutoscaleConfig {
-    if c.MinWorkers <= 0 {
-        c.MinWorkers = 1
-    }
-    if c.MaxWorkers <= 0 {
-        c.MaxWorkers = runtime.NumCPU()
-    }
-    // ... etc
-}
-```
+## Convention Alignment
+
+The implementation follows repository conventions:
+
+| Pattern | Implementation |
+|---------|----------------|
+| Config defaults | `defaultAutoscaleConfig` variable + `parse()` method |
+| Internal packages | `pipe/internal/autoscale/` for pool implementation |
+| Dispatcher pattern | `startProcessing()` dispatches to `startStaticProcessing()` or `startAutoscaledProcessing()` |
+| No type duplication | Single `AutoscaleConfig` in pipe package, `PoolConfig` in internal |
 
 ## Verification
 
-1. **Unit tests**: Test min/max enforcement, scale-up triggers, scale-down on idle, cooldowns
-2. **Integration test**: Create pipe with autoscale, send burst of items, verify workers scale up, wait for idle, verify scale down
-3. **Manual test**: Run example with logging to observe scaling behavior
+- **Unit tests**: 15+ tests covering min/max enforcement, scale-up triggers, scale-down on idle, cooldowns, goroutine leak detection
+- **Benchmarks**: Comparison between static and autoscale processing under various loads
+- **All tests pass**: `go test ./...` succeeds
 
 ## Future Enhancements (out of scope for v1)
 

--- a/docs/plans/pipe-autoscaling.md
+++ b/docs/plans/pipe-autoscaling.md
@@ -1,0 +1,219 @@
+# Dynamic Concurrency Autoscaling for gopipe
+
+**Status:** Implemented
+
+## Overview
+
+Replace the static `Concurrency int` configuration with a dynamic autoscaling system that supports min/max bounds and automatically adjusts worker count based on load.
+
+## Current State
+
+- `pipe/processing.go`: `Config.Concurrency` is a static int (default 1)
+- Workers spawned once at startup: `wg.Add(cfg.Concurrency)` + `for range cfg.Concurrency`
+- No runtime adjustment of worker count
+
+## Design Approach
+
+**Backpressure-based scaling** (validated against industry patterns):
+
+| Library | Scale-Up Method | Scale-Down Method |
+|---------|-----------------|-------------------|
+| **Pond** | All workers busy + queue depth | Immediate on idle or IdleTimeout |
+| **Ants** | Fixed capacity (no autoscale) | Periodic scavenger (ExpiryDuration, default 1s) |
+| **workerpool-go** | Load avg > threshold (EWMA) | Load avg < threshold |
+| **Watermill** | N/A (partition-based, implicit) | N/A |
+
+**Our approach** (aligns with Pond's simpler model):
+- Scale up: when all workers are busy (activeWorkers == totalWorkers) AND workers < max
+- Scale down: when a worker has been idle for `ScaleDownAfter` AND workers > min
+- Cooldown periods prevent thrashing
+
+**Why not Watermill's approach?** Watermill relies on message broker partitions for parallelism. gopipe is a general-purpose pipeline library, so explicit worker management is more appropriate.
+
+## New Files
+
+```
+pipe/internal/autoscale/
+├── pool.go       # Pool struct, worker management, Start/Stop
+├── scaler.go     # Scaling decision loop
+├── config.go     # Internal config with defaults
+└── pool_test.go  # Unit tests
+```
+
+## Configuration API
+
+```go
+// In pipe/processing.go - add to Config struct
+type Config struct {
+    Concurrency int  // Static workers (ignored when Autoscale is set)
+
+    // NEW: Dynamic scaling config
+    Autoscale *AutoscaleConfig
+
+    // ... existing fields unchanged ...
+}
+
+// New type in pipe/autoscale.go (or inline in processing.go)
+type AutoscaleConfig struct {
+    MinWorkers        int           // Default: 1
+    MaxWorkers        int           // Default: runtime.NumCPU()
+    ScaleDownAfter    time.Duration // Idle duration before scale-down. Default: 30s
+    ScaleUpCooldown   time.Duration // Min time between scale-ups. Default: 5s
+    ScaleDownCooldown time.Duration // Min time between scale-downs. Default: 10s
+    CheckInterval     time.Duration // How often to evaluate. Default: 1s
+}
+```
+
+## Usage Examples
+
+```go
+// Existing usage - unchanged (backward compatible)
+p := pipe.NewProcessPipe(fn, pipe.Config{Concurrency: 4})
+
+// New autoscaling usage
+p := pipe.NewProcessPipe(fn, pipe.Config{
+    Autoscale: &pipe.AutoscaleConfig{
+        MinWorkers: 2,
+        MaxWorkers: 16,
+    },
+})
+```
+
+## Implementation Steps
+
+### 1. Create internal autoscale package
+- `pipe/internal/autoscale/config.go`: Internal config struct with `parse()` method
+- `pipe/internal/autoscale/pool.go`: Pool struct managing workers map, spawn/stop logic
+
+### 2. Implement worker management
+- Worker struct with id, stopCh, lastActive, idle state
+- `spawnWorker()` / `stopWorker()` methods
+- Idle tracking: mark active when processing, idle when waiting
+
+### 3. Implement scaler loop
+- `runScaler()` goroutine with ticker at CheckInterval
+- Backpressure detection: scale up when `activeWorkers == totalWorkers` (all busy)
+- Idle detection: scale down when worker's `lastActive` exceeds `ScaleDownAfter`
+- Cooldown enforcement to prevent thrashing
+
+### 4. Integrate with startProcessing()
+- Check if `cfg.Autoscale != nil`
+- If yes, delegate to `startAutoscaledProcessing()`
+- If no, use existing static worker loop (unchanged)
+
+### 5. Add tests
+- Unit tests for pool scaling behavior
+- Integration tests with varying load patterns
+- Verify backward compatibility
+
+## Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `pipe/processing.go` | Add `Autoscale *AutoscaleConfig` to Config, add `startAutoscaledProcessing()` |
+| `pipe/internal/autoscale/pool.go` | NEW: Pool implementation |
+| `pipe/internal/autoscale/scaler.go` | NEW: Scaling logic |
+| `pipe/internal/autoscale/config.go` | NEW: Config with defaults |
+
+## Load Detection (Pending Counter Approach)
+
+The pending counter approach detects backpressure by tracking active vs total workers:
+
+```go
+type Pool struct {
+    mu            sync.Mutex
+    workers       map[int]*worker   // all spawned workers
+    totalWorkers  atomic.Int64      // count of spawned workers
+    activeWorkers atomic.Int64      // workers currently processing (not idle)
+}
+
+type worker struct {
+    id         int
+    lastActive time.Time     // last time worker finished processing
+    stopCh     chan struct{} // signal to stop this worker
+}
+```
+
+**Worker lifecycle:**
+```go
+func (p *Pool) runWorker(w *worker, in <-chan In, fn ProcessFunc) {
+    for {
+        select {
+        case <-w.stopCh:
+            return
+        case val, ok := <-in:
+            if !ok {
+                return
+            }
+            p.activeWorkers.Add(1)       // mark as busy
+            result, err := fn(ctx, val)
+            p.activeWorkers.Add(-1)      // mark as available
+
+            p.mu.Lock()
+            w.lastActive = time.Now()    // track for idle detection
+            p.mu.Unlock()
+
+            // ... handle result/error ...
+        }
+    }
+}
+```
+
+**Scale-up decision:**
+```go
+// If all workers are busy (activeWorkers == totalWorkers) for sustained period
+if p.activeWorkers.Load() >= p.totalWorkers.Load() &&
+   time.Since(lastScaleUp) >= cfg.ScaleUpCooldown &&
+   p.totalWorkers.Load() < cfg.MaxWorkers {
+    p.spawnWorker()
+}
+```
+
+**Scale-down decision:**
+```go
+// Find workers idle for too long
+for _, w := range p.workers {
+    if time.Since(w.lastActive) >= cfg.ScaleDownAfter &&
+       p.totalWorkers.Load() > cfg.MinWorkers {
+        close(w.stopCh)  // gracefully stop this worker
+        break  // scale down one at a time
+    }
+}
+```
+
+## Default Values (0 = auto)
+
+| Field | 0 means | Default value |
+|-------|---------|---------------|
+| MinWorkers | use default | 1 |
+| MaxWorkers | use default | runtime.NumCPU() |
+| ScaleUpCooldown | use default | 5s |
+| ScaleDownCooldown | use default | 10s |
+| ScaleDownAfter | use default | 30s |
+| CheckInterval | use default | 1s |
+
+```go
+func (c AutoscaleConfig) parse() AutoscaleConfig {
+    if c.MinWorkers <= 0 {
+        c.MinWorkers = 1
+    }
+    if c.MaxWorkers <= 0 {
+        c.MaxWorkers = runtime.NumCPU()
+    }
+    // ... etc
+}
+```
+
+## Verification
+
+1. **Unit tests**: Test min/max enforcement, scale-up triggers, scale-down on idle, cooldowns
+2. **Integration test**: Create pipe with autoscale, send burst of items, verify workers scale up, wait for idle, verify scale down
+3. **Manual test**: Run example with logging to observe scaling behavior
+
+## Future Enhancements (out of scope for v1)
+
+Based on research, these could be added later:
+- **Strategies** (like Pond): Eager/Balanced/Lazy scaling aggressiveness
+- **EWMA load averaging** (like workerpool-go): Smoother scaling decisions
+- **Metrics callbacks**: OnScaleUp/OnScaleDown hooks for observability
+- **Custom ScaleStrategy interface**: User-defined scaling logic (like gopool)

--- a/docs/plans/pipe-ordering.md
+++ b/docs/plans/pipe-ordering.md
@@ -1,0 +1,318 @@
+# Preserved Message Ordering for Worker Pool
+
+**Status:** Proposed
+
+**Depends on:** [pipe-autoscaling](pipe-autoscaling.md) (PoolConfig naming convention)
+
+## Overview
+
+Add optional preserved message ordering to the worker pool. When enabled, outputs are delivered in the same order as inputs, despite parallel processing by multiple workers.
+
+## Motivation
+
+Concurrent processing improves throughput but loses input order:
+
+```
+Without ordering (current behavior):
+  Input:  [A, B, C, D]  (A is slow, B/C/D are fast)
+  Output: [B, C, D, A]  (completion order)
+
+With ordering (this proposal):
+  Input:  [A, B, C, D]
+  Output: [A, B, C, D]  (input order preserved)
+```
+
+**Use cases:**
+- Event sourcing where order matters
+- Stream processing with sequence dependencies
+- Audit logs requiring chronological order
+- Any pipeline where downstream expects ordered data
+
+## Design
+
+### Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │         Worker Pool             │
+                    │   ┌─────────┐                   │
+Input → [Sequencer] │   │ Worker1 │──┐               │
+         (seq++)    │   ├─────────┤  │               │
+                    │   │ Worker2 │──┼─→ [Reorderer] │ → Output
+                    │   ├─────────┤  │    (buffer)   │
+                    │   │ WorkerN │──┘               │
+                    │   └─────────┘                  │
+                    │    ↑ static or autoscale ↓     │
+                    └─────────────────────────────────┘
+```
+
+**Components:**
+1. **Sequencer**: Single goroutine assigns monotonic sequence numbers to inputs
+2. **Workers**: Process in parallel (existing static or autoscale logic)
+3. **Reorderer**: Single goroutine buffers out-of-order results, releases in sequence
+
+### Mechanism
+
+```go
+// Internal types
+type sequenced[T any] struct {
+    seq uint64
+    val T
+}
+
+type sequencedResult[T any] struct {
+    seq     uint64
+    results []T  // ProcessFunc can return multiple outputs
+}
+```
+
+**Sequencer** (input side):
+```go
+func sequenceInputs[T any](in <-chan T) <-chan sequenced[T] {
+    out := make(chan sequenced[T])
+    go func() {
+        defer close(out)
+        var seq uint64
+        for v := range in {
+            out <- sequenced[T]{seq: seq, val: v}
+            seq++
+        }
+    }()
+    return out
+}
+```
+
+**Reorderer** (output side):
+```go
+type reorderer[T any] struct {
+    nextSeq    uint64
+    buffer     map[uint64][]T  // or min-heap for efficiency
+    bufferSize int
+}
+
+func (r *reorderer[T]) receive(item sequencedResult[T]) []T {
+    if item.seq == r.nextSeq {
+        // In order - emit immediately, then drain consecutive buffered
+        return r.emitConsecutive(item.results)
+    }
+    // Out of order - buffer
+    r.buffer[item.seq] = item.results
+    return nil
+}
+
+func (r *reorderer[T]) emitConsecutive(first []T) []T {
+    result := first
+    r.nextSeq++
+    for {
+        if next, ok := r.buffer[r.nextSeq]; ok {
+            delete(r.buffer, r.nextSeq)
+            result = append(result, next...)
+            r.nextSeq++
+        } else {
+            break
+        }
+    }
+    return result
+}
+```
+
+### Configuration API
+
+```go
+type PoolConfig struct {
+    // ... existing fields from pipe-autoscaling.md ...
+    Workers         int
+    Autoscale       *AutoscaleConfig
+    BufferSize      int
+    ErrorHandler    func(in any, err error)
+    // ...
+
+    // PreserveOrder enables in-order message delivery.
+    // When true, outputs are reordered to match input sequence
+    // despite parallel processing. Has memory/latency overhead.
+    // Default: false
+    PreserveOrder bool
+
+    // OrderBufferSize is the max items to buffer while waiting
+    // for in-sequence items. Only used when PreserveOrder is true.
+    // When buffer fills, workers block (backpressure).
+    // Default: max(Workers, MaxWorkers) * 2
+    OrderBufferSize int
+}
+```
+
+### Processing Dispatcher Update
+
+```go
+func startProcessing[In, Out any](...) <-chan Out {
+    cfg = cfg.parse()
+
+    if cfg.PreserveOrder {
+        return startOrderedProcessing(ctx, in, fn, cfg)
+    }
+    if cfg.Autoscale != nil {
+        return startAutoscaledProcessing(ctx, in, fn, cfg)
+    }
+    return startStaticProcessing(ctx, in, fn, cfg)
+}
+
+func startOrderedProcessing[In, Out any](...) <-chan Out {
+    // 1. Wrap inputs with sequence numbers
+    seqIn := sequenceInputs(in)
+
+    // 2. Wrap ProcessFunc to carry sequence through
+    seqFn := func(ctx context.Context, s sequenced[In]) ([]sequencedResult[Out], error) {
+        results, err := fn(ctx, s.val)
+        if err != nil {
+            return nil, err
+        }
+        return []sequencedResult[Out]{{seq: s.seq, results: results}}, nil
+    }
+
+    // 3. Process using existing workers (static or autoscale)
+    var seqOut <-chan sequencedResult[Out]
+    if cfg.Autoscale != nil {
+        seqOut = startAutoscaledProcessing(ctx, seqIn, seqFn, cfg)
+    } else {
+        seqOut = startStaticProcessing(ctx, seqIn, seqFn, cfg)
+    }
+
+    // 4. Reorder outputs
+    return reorderOutputs(seqOut, cfg.OrderBufferSize)
+}
+```
+
+## Performance Characteristics
+
+### Benefits
+
+| Scenario | Impact |
+|----------|--------|
+| Variable processing times | **High** - fast items complete while slow ones block sequential processing |
+| I/O-bound work | **High** - parallel I/O wait amortizes latency |
+| CPU-bound with multi-core | **Moderate** - true parallelism benefits |
+
+### Overhead
+
+| Component | Cost |
+|-----------|------|
+| Sequencer | Minimal - single atomic increment per item |
+| Reorderer | O(1) map operations, bounded memory |
+| Wrapping | One allocation per item for `sequenced[T]` struct |
+
+### Head-of-Line Blocking
+
+This is the fundamental trade-off of ordered delivery:
+
+```
+Scenario: Item 0 takes 5s, items 1-99 take 10ms each
+
+Timeline:
+  t=0:     Item 0 starts on Worker1
+  t=10ms:  Item 1 done, buffered (waiting for 0)
+  t=20ms:  Item 2 done, buffered
+  ...
+  t=990ms: Buffer full (OrderBufferSize items), workers block
+  t=5s:    Item 0 done, buffer drains instantly
+
+Result: ~5s apparent stall, then burst of 100 outputs
+```
+
+**This is inherent to ordering guarantees, not a design flaw.**
+
+**Mitigations:**
+1. Larger `OrderBufferSize` (trades memory for throughput)
+2. Design ProcessFuncs to have bounded execution time
+3. Use circuit breakers/timeouts in ProcessFunc for slow operations
+
+## Compatibility
+
+### Works with Static Workers
+
+```go
+p := pipe.NewProcessPipe(fn, pipe.PoolConfig{
+    Workers:       4,
+    PreserveOrder: true,
+})
+```
+
+### Works with Autoscaling
+
+```go
+p := pipe.NewProcessPipe(fn, pipe.PoolConfig{
+    Autoscale: &pipe.AutoscaleConfig{
+        MinWorkers: 2,
+        MaxWorkers: 16,
+    },
+    PreserveOrder:   true,
+    OrderBufferSize: 32,  // 2x MaxWorkers
+})
+```
+
+**Note:** With autoscaling, `OrderBufferSize` should be based on `MaxWorkers` to accommodate maximum spread of in-flight items.
+
+### Autoscaling Considerations
+
+| Aspect | Impact |
+|--------|--------|
+| Scale-up trigger | Works normally - scaler sees input queue depth |
+| Scale-down | Works normally - idle workers still scale down |
+| Buffer sizing | Should use `MaxWorkers`, not current worker count |
+| Backpressure | Reorderer buffer full → workers block → input queue grows → may trigger scale-up |
+
+## Implementation Plan
+
+### File Structure
+
+```
+pipe/
+├── pool.go                   # Add PreserveOrder, OrderBufferSize fields
+├── ordering.go               # NEW: sequenced types, sequenceInputs, reorderOutputs
+├── processing.go             # Add startOrderedProcessing dispatcher
+└── internal/autoscale/
+    └── ...                   # No changes needed
+```
+
+### Implementation Steps
+
+1. Add `PreserveOrder` and `OrderBufferSize` to `PoolConfig`
+2. Create `ordering.go` with sequencer and reorderer
+3. Update `startProcessing` dispatcher
+4. Add tests for ordered static processing
+5. Add tests for ordered autoscale processing
+6. Add benchmark comparing ordered vs unordered
+
+## Alternatives Considered
+
+### Partitioned Workers (Kafka-style)
+
+Messages with same key go to same worker, preserving order within partitions.
+
+**Pros:** Efficient, no reorder buffer needed
+**Cons:** Only partial ordering (per-key), requires key function
+
+**Verdict:** Could be added as `PartitionKey func(In) string` for use cases that don't need total ordering.
+
+### Single Worker When Ordered
+
+Use `Workers: 1` when ordering is needed.
+
+**Pros:** Trivially correct
+**Cons:** Defeats purpose of concurrency, no throughput benefit
+
+**Verdict:** User can already do this; `PreserveOrder` provides ordered + parallel.
+
+### Slot-based Ring Buffer
+
+Pre-allocate slots, workers claim slots before processing.
+
+**Pros:** Fixed memory, no map overhead
+**Cons:** More complex coordination, harder to handle multi-output ProcessFunc
+
+**Verdict:** Map-based reorderer is simpler and sufficient for expected use cases.
+
+## Future Extensions (out of scope)
+
+- **PartitionKey**: Order within partitions only (like Kafka consumer groups)
+- **OrderTimeout**: Skip sequence gap after timeout (trades correctness for throughput)
+- **Metrics**: Buffer utilization, head-of-line blocking duration

--- a/pipe/autoscale.go
+++ b/pipe/autoscale.go
@@ -1,6 +1,9 @@
 package pipe
 
-import "time"
+import (
+	"runtime"
+	"time"
+)
 
 // AutoscaleConfig configures dynamic worker scaling for ProcessPipe.
 // When set on Config, enables automatic adjustment of worker count based on load.
@@ -32,4 +35,38 @@ type AutoscaleConfig struct {
 	// CheckInterval is how often the scaler evaluates whether to adjust workers.
 	// Default: 1s
 	CheckInterval time.Duration
+}
+
+var defaultAutoscaleConfig = AutoscaleConfig{
+	MinWorkers:        1,
+	MaxWorkers:        0, // Will be set to runtime.NumCPU() in parse()
+	ScaleDownAfter:    30 * time.Second,
+	ScaleUpCooldown:   5 * time.Second,
+	ScaleDownCooldown: 10 * time.Second,
+	CheckInterval:     1 * time.Second,
+}
+
+func (c AutoscaleConfig) parse() AutoscaleConfig {
+	if c.MinWorkers <= 0 {
+		c.MinWorkers = defaultAutoscaleConfig.MinWorkers
+	}
+	if c.MaxWorkers <= 0 {
+		c.MaxWorkers = runtime.NumCPU()
+	}
+	if c.MinWorkers > c.MaxWorkers {
+		c.MinWorkers = c.MaxWorkers
+	}
+	if c.ScaleDownAfter <= 0 {
+		c.ScaleDownAfter = defaultAutoscaleConfig.ScaleDownAfter
+	}
+	if c.ScaleUpCooldown <= 0 {
+		c.ScaleUpCooldown = defaultAutoscaleConfig.ScaleUpCooldown
+	}
+	if c.ScaleDownCooldown <= 0 {
+		c.ScaleDownCooldown = defaultAutoscaleConfig.ScaleDownCooldown
+	}
+	if c.CheckInterval <= 0 {
+		c.CheckInterval = defaultAutoscaleConfig.CheckInterval
+	}
+	return c
 }

--- a/pipe/autoscale.go
+++ b/pipe/autoscale.go
@@ -1,0 +1,35 @@
+package pipe
+
+import "time"
+
+// AutoscaleConfig configures dynamic worker scaling for ProcessPipe.
+// When set on Config, enables automatic adjustment of worker count based on load.
+//
+// Zero values for any field use sensible defaults (see field documentation).
+type AutoscaleConfig struct {
+	// MinWorkers is the minimum number of workers to maintain.
+	// Default: 1
+	MinWorkers int
+
+	// MaxWorkers is the maximum number of workers to scale up to.
+	// Default: runtime.NumCPU()
+	MaxWorkers int
+
+	// ScaleDownAfter is how long a worker must be idle before being stopped.
+	// Default: 30s
+	ScaleDownAfter time.Duration
+
+	// ScaleUpCooldown is the minimum time between scale-up operations.
+	// Prevents thrashing when load spikes briefly.
+	// Default: 5s
+	ScaleUpCooldown time.Duration
+
+	// ScaleDownCooldown is the minimum time between scale-down operations.
+	// Prevents thrashing when load fluctuates.
+	// Default: 10s
+	ScaleDownCooldown time.Duration
+
+	// CheckInterval is how often the scaler evaluates whether to adjust workers.
+	// Default: 1s
+	CheckInterval time.Duration
+}

--- a/pipe/go.sum
+++ b/pipe/go.sum
@@ -1,0 +1,2 @@
+github.com/fxsml/gopipe/channel v0.11.0 h1:DnBDcOhJdm/2gfSYbZhr09PKhA1ZTtTbRQ2nkUCkLAg=
+github.com/fxsml/gopipe/channel v0.11.0/go.mod h1:KU0JFSXWGZnenOeWKWNU5CCfnfMWiKwtmjXh5bOS6r4=

--- a/pipe/internal/autoscale/config.go
+++ b/pipe/internal/autoscale/config.go
@@ -1,11 +1,8 @@
 package autoscale
 
-import (
-	"runtime"
-	"time"
-)
+import "time"
 
-// Default configuration values.
+// Default configuration values for testing and documentation.
 const (
 	DefaultMinWorkers        = 1
 	DefaultScaleDownAfter    = 30 * time.Second
@@ -13,52 +10,3 @@ const (
 	DefaultScaleDownCooldown = 10 * time.Second
 	DefaultCheckInterval     = 1 * time.Second
 )
-
-// Config holds the parsed autoscale configuration with defaults applied.
-type Config struct {
-	MinWorkers        int
-	MaxWorkers        int
-	ScaleDownAfter    time.Duration
-	ScaleUpCooldown   time.Duration
-	ScaleDownCooldown time.Duration
-	CheckInterval     time.Duration
-}
-
-// Parse converts external configuration to internal config with defaults.
-func Parse(
-	minWorkers, maxWorkers int,
-	scaleDownAfter, scaleUpCooldown, scaleDownCooldown, checkInterval time.Duration,
-) Config {
-	cfg := Config{
-		MinWorkers:        minWorkers,
-		MaxWorkers:        maxWorkers,
-		ScaleDownAfter:    scaleDownAfter,
-		ScaleUpCooldown:   scaleUpCooldown,
-		ScaleDownCooldown: scaleDownCooldown,
-		CheckInterval:     checkInterval,
-	}
-
-	if cfg.MinWorkers <= 0 {
-		cfg.MinWorkers = DefaultMinWorkers
-	}
-	if cfg.MaxWorkers <= 0 {
-		cfg.MaxWorkers = runtime.NumCPU()
-	}
-	if cfg.MinWorkers > cfg.MaxWorkers {
-		cfg.MinWorkers = cfg.MaxWorkers
-	}
-	if cfg.ScaleDownAfter <= 0 {
-		cfg.ScaleDownAfter = DefaultScaleDownAfter
-	}
-	if cfg.ScaleUpCooldown <= 0 {
-		cfg.ScaleUpCooldown = DefaultScaleUpCooldown
-	}
-	if cfg.ScaleDownCooldown <= 0 {
-		cfg.ScaleDownCooldown = DefaultScaleDownCooldown
-	}
-	if cfg.CheckInterval <= 0 {
-		cfg.CheckInterval = DefaultCheckInterval
-	}
-
-	return cfg
-}

--- a/pipe/internal/autoscale/config.go
+++ b/pipe/internal/autoscale/config.go
@@ -1,0 +1,64 @@
+package autoscale
+
+import (
+	"runtime"
+	"time"
+)
+
+// Default configuration values.
+const (
+	DefaultMinWorkers        = 1
+	DefaultScaleDownAfter    = 30 * time.Second
+	DefaultScaleUpCooldown   = 5 * time.Second
+	DefaultScaleDownCooldown = 10 * time.Second
+	DefaultCheckInterval     = 1 * time.Second
+)
+
+// Config holds the parsed autoscale configuration with defaults applied.
+type Config struct {
+	MinWorkers        int
+	MaxWorkers        int
+	ScaleDownAfter    time.Duration
+	ScaleUpCooldown   time.Duration
+	ScaleDownCooldown time.Duration
+	CheckInterval     time.Duration
+}
+
+// Parse converts external configuration to internal config with defaults.
+func Parse(
+	minWorkers, maxWorkers int,
+	scaleDownAfter, scaleUpCooldown, scaleDownCooldown, checkInterval time.Duration,
+) Config {
+	cfg := Config{
+		MinWorkers:        minWorkers,
+		MaxWorkers:        maxWorkers,
+		ScaleDownAfter:    scaleDownAfter,
+		ScaleUpCooldown:   scaleUpCooldown,
+		ScaleDownCooldown: scaleDownCooldown,
+		CheckInterval:     checkInterval,
+	}
+
+	if cfg.MinWorkers <= 0 {
+		cfg.MinWorkers = DefaultMinWorkers
+	}
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = runtime.NumCPU()
+	}
+	if cfg.MinWorkers > cfg.MaxWorkers {
+		cfg.MinWorkers = cfg.MaxWorkers
+	}
+	if cfg.ScaleDownAfter <= 0 {
+		cfg.ScaleDownAfter = DefaultScaleDownAfter
+	}
+	if cfg.ScaleUpCooldown <= 0 {
+		cfg.ScaleUpCooldown = DefaultScaleUpCooldown
+	}
+	if cfg.ScaleDownCooldown <= 0 {
+		cfg.ScaleDownCooldown = DefaultScaleDownCooldown
+	}
+	if cfg.CheckInterval <= 0 {
+		cfg.CheckInterval = DefaultCheckInterval
+	}
+
+	return cfg
+}

--- a/pipe/internal/autoscale/pool.go
+++ b/pipe/internal/autoscale/pool.go
@@ -1,0 +1,256 @@
+package autoscale
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ProcessFunc is the core processing function signature.
+type ProcessFunc[In, Out any] func(ctx context.Context, in In) ([]Out, error)
+
+// ErrorHandler handles processing errors.
+type ErrorHandler func(in any, err error)
+
+// Pool manages a dynamic pool of workers that scales based on load.
+type Pool[In, Out any] struct {
+	cfg          Config
+	fn           ProcessFunc[In, Out]
+	errorHandler ErrorHandler
+	shutdownErr  error // Error to report when shutdown drops messages
+
+	mu       sync.Mutex
+	workers  map[int]*worker
+	nextID   int
+	stopping bool
+
+	totalWorkers  atomic.Int64
+	activeWorkers atomic.Int64
+
+	lastScaleUp   time.Time
+	lastScaleDown time.Time
+
+	in   <-chan In
+	out  chan Out
+	done chan struct{}
+
+	workerWg sync.WaitGroup // Tracks only workers
+	scalerWg sync.WaitGroup // Tracks the scaler goroutine
+}
+
+type worker struct {
+	id         int
+	lastActive time.Time
+	stopCh     chan struct{}
+}
+
+// NewPool creates a new autoscaling worker pool.
+func NewPool[In, Out any](
+	cfg Config,
+	fn ProcessFunc[In, Out],
+	errorHandler ErrorHandler,
+	shutdownErr error,
+) *Pool[In, Out] {
+	return &Pool[In, Out]{
+		cfg:          cfg,
+		fn:           fn,
+		errorHandler: errorHandler,
+		shutdownErr:  shutdownErr,
+		workers:      make(map[int]*worker),
+	}
+}
+
+// Start begins processing items from the input channel and returns the output channel.
+func (p *Pool[In, Out]) Start(ctx context.Context, in <-chan In, bufferSize int) <-chan Out {
+	p.in = in
+	p.out = make(chan Out, bufferSize)
+	p.done = make(chan struct{})
+
+	// Spawn initial workers (MinWorkers)
+	for range p.cfg.MinWorkers {
+		p.spawnWorker(ctx)
+	}
+
+	// Start the scaler goroutine
+	p.scalerWg.Add(1)
+	go p.runScaler(ctx)
+
+	// Start a goroutine to wait for all workers and close output
+	go p.waitForCompletion()
+
+	return p.out
+}
+
+// TotalWorkers returns the current number of workers.
+func (p *Pool[In, Out]) TotalWorkers() int64 {
+	return p.totalWorkers.Load()
+}
+
+// ActiveWorkers returns the number of workers currently processing.
+func (p *Pool[In, Out]) ActiveWorkers() int64 {
+	return p.activeWorkers.Load()
+}
+
+func (p *Pool[In, Out]) spawnWorker(ctx context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stopping {
+		return
+	}
+
+	if p.totalWorkers.Load() >= int64(p.cfg.MaxWorkers) {
+		return
+	}
+
+	w := &worker{
+		id:         p.nextID,
+		lastActive: time.Now(),
+		stopCh:     make(chan struct{}),
+	}
+	p.nextID++
+	p.workers[w.id] = w
+	p.totalWorkers.Add(1)
+
+	p.workerWg.Add(1)
+	go p.runWorker(ctx, w)
+}
+
+func (p *Pool[In, Out]) stopWorker(id int) {
+	p.mu.Lock()
+	w, ok := p.workers[id]
+	if !ok {
+		p.mu.Unlock()
+		return
+	}
+	delete(p.workers, id)
+	p.mu.Unlock()
+
+	close(w.stopCh)
+	p.totalWorkers.Add(-1)
+}
+
+func (p *Pool[In, Out]) runWorker(ctx context.Context, w *worker) {
+	defer p.workerWg.Done()
+
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-p.done:
+			return
+		case val, ok := <-p.in:
+			if !ok {
+				return
+			}
+
+			p.activeWorkers.Add(1)
+			results, err := p.fn(ctx, val)
+			p.activeWorkers.Add(-1)
+
+			p.mu.Lock()
+			w.lastActive = time.Now()
+			p.mu.Unlock()
+
+			if err != nil {
+				p.errorHandler(val, err)
+				continue
+			}
+
+			for i, r := range results {
+				select {
+				case p.out <- r:
+				case <-p.done:
+					// Report this and remaining outputs as dropped
+					for _, dropped := range results[i:] {
+						p.errorHandler(dropped, p.shutdownErr)
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+func (p *Pool[In, Out]) runScaler(ctx context.Context) {
+	defer p.scalerWg.Done()
+
+	ticker := time.NewTicker(p.cfg.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.done:
+			return
+		case <-ticker.C:
+			p.evaluate()
+		}
+	}
+}
+
+func (p *Pool[In, Out]) evaluate() {
+	now := time.Now()
+	total := p.totalWorkers.Load()
+	active := p.activeWorkers.Load()
+
+	// Scale up: all workers busy and below max
+	if active >= total &&
+		total < int64(p.cfg.MaxWorkers) &&
+		now.Sub(p.lastScaleUp) >= p.cfg.ScaleUpCooldown {
+		p.spawnWorker(context.Background())
+		p.lastScaleUp = now
+		return
+	}
+
+	// Scale down: find idle workers
+	if total > int64(p.cfg.MinWorkers) &&
+		now.Sub(p.lastScaleDown) >= p.cfg.ScaleDownCooldown {
+		p.mu.Lock()
+		var idleWorkerID = -1
+		for id, w := range p.workers {
+			if now.Sub(w.lastActive) >= p.cfg.ScaleDownAfter {
+				idleWorkerID = id
+				break
+			}
+		}
+		p.mu.Unlock()
+
+		if idleWorkerID >= 0 {
+			p.stopWorker(idleWorkerID)
+			p.lastScaleDown = now
+		}
+	}
+}
+
+func (p *Pool[In, Out]) waitForCompletion() {
+	// Wait for all workers to finish (they exit when input channel closes)
+	p.workerWg.Wait()
+
+	// Signal scaler to stop
+	p.mu.Lock()
+	if !p.stopping {
+		p.stopping = true
+		close(p.done)
+	}
+	p.mu.Unlock()
+
+	// Wait for scaler to finish
+	p.scalerWg.Wait()
+
+	// Close output channel
+	close(p.out)
+}
+
+// Stop signals all workers to stop.
+func (p *Pool[In, Out]) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.stopping {
+		p.stopping = true
+		close(p.done)
+	}
+}

--- a/pipe/internal/autoscale/pool_test.go
+++ b/pipe/internal/autoscale/pool_test.go
@@ -1,0 +1,279 @@
+package autoscale
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPool_MinWorkers(t *testing.T) {
+	cfg := Parse(2, 10, 30*time.Second, 5*time.Second, 10*time.Second, 100*time.Millisecond)
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		return []int{in * 2}, nil
+	}
+
+	pool := NewPool(cfg, fn, func(any, error) {}, nil)
+
+	in := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool.Start(ctx, in, 0)
+
+	// Give time for workers to spawn
+	time.Sleep(50 * time.Millisecond)
+
+	if pool.TotalWorkers() != 2 {
+		t.Errorf("expected 2 workers, got %d", pool.TotalWorkers())
+	}
+
+	close(in)
+}
+
+func TestPool_MaxWorkers(t *testing.T) {
+	// Use very short intervals for faster test
+	cfg := Parse(1, 3, 30*time.Second, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond)
+
+	var processing atomic.Int32
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		processing.Add(1)
+		time.Sleep(200 * time.Millisecond) // Simulate slow processing
+		processing.Add(-1)
+		return []int{in * 2}, nil
+	}
+
+	pool := NewPool(cfg, fn, func(any, error) {}, nil)
+
+	in := make(chan int, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool.Start(ctx, in, 10)
+
+	// Send many items to trigger scale-up
+	for i := range 10 {
+		in <- i
+	}
+
+	// Wait for scaling to happen
+	time.Sleep(150 * time.Millisecond)
+
+	// Should have scaled up to max (3)
+	total := pool.TotalWorkers()
+	if total > 3 {
+		t.Errorf("expected at most 3 workers, got %d", total)
+	}
+
+	close(in)
+}
+
+func TestPool_ScaleUp(t *testing.T) {
+	// Short cooldowns for faster test
+	cfg := Parse(1, 5, 30*time.Second, 20*time.Millisecond, 10*time.Second, 10*time.Millisecond)
+
+	var mu sync.Mutex
+	blocked := make(chan struct{})
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		mu.Lock()
+		mu.Unlock()
+		<-blocked
+		return []int{in * 2}, nil
+	}
+
+	pool := NewPool(cfg, fn, func(any, error) {}, nil)
+
+	in := make(chan int, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool.Start(ctx, in, 10)
+
+	// Block the mutex so workers can't proceed past the lock
+	mu.Lock()
+
+	// Send items - workers will block
+	for i := range 5 {
+		in <- i
+	}
+
+	// Wait for initial workers to start processing (and block on the mutex)
+	time.Sleep(30 * time.Millisecond)
+
+	// All workers should be active (blocked)
+	// Scaler should detect all workers busy and scale up
+
+	// Wait for scaler cycles to run
+	time.Sleep(100 * time.Millisecond)
+
+	total := pool.TotalWorkers()
+	if total < 2 {
+		t.Errorf("expected workers to scale up from 1, got %d", total)
+	}
+
+	// Cleanup
+	mu.Unlock()
+	close(blocked)
+	close(in)
+}
+
+func TestPool_ScaleDown(t *testing.T) {
+	// Very short scale-down time for test
+	cfg := Parse(1, 5, 50*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond)
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		return []int{in * 2}, nil
+	}
+
+	pool := NewPool(cfg, fn, func(any, error) {}, nil)
+
+	in := make(chan int, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool.Start(ctx, in, 100)
+
+	// Send burst of items to trigger scale-up
+	for i := range 50 {
+		in <- i
+	}
+
+	// Wait for scaling up and processing
+	time.Sleep(150 * time.Millisecond)
+
+	totalAfterBurst := pool.TotalWorkers()
+
+	// Now wait with no new items - should scale down
+	time.Sleep(200 * time.Millisecond)
+
+	totalAfterIdle := pool.TotalWorkers()
+
+	if totalAfterIdle >= totalAfterBurst && totalAfterBurst > 1 {
+		t.Errorf("expected workers to scale down after idle, got before=%d after=%d",
+			totalAfterBurst, totalAfterIdle)
+	}
+
+	// Should not go below min
+	if totalAfterIdle < 1 {
+		t.Errorf("workers scaled below minimum: %d", totalAfterIdle)
+	}
+
+	close(in)
+}
+
+func TestPool_ProcessesAllItems(t *testing.T) {
+	cfg := Parse(2, 8, 30*time.Second, 50*time.Millisecond, 100*time.Millisecond, 20*time.Millisecond)
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		return []int{in * 2}, nil
+	}
+
+	pool := NewPool(cfg, fn, func(any, error) {}, nil)
+
+	in := make(chan int)
+	ctx := context.Background()
+
+	out := pool.Start(ctx, in, 100)
+
+	// Send items
+	go func() {
+		for i := range 100 {
+			in <- i
+		}
+		close(in)
+	}()
+
+	// Collect results
+	var results []int
+	for v := range out {
+		results = append(results, v)
+	}
+
+	if len(results) != 100 {
+		t.Errorf("expected 100 results, got %d", len(results))
+	}
+}
+
+func TestPool_ErrorHandler(t *testing.T) {
+	cfg := Parse(1, 1, 30*time.Second, 5*time.Second, 10*time.Second, 100*time.Millisecond)
+
+	var mu sync.Mutex
+	var errors []int
+
+	fn := func(ctx context.Context, in int) ([]int, error) {
+		if in < 0 {
+			return nil, context.DeadlineExceeded
+		}
+		return []int{in * 2}, nil
+	}
+
+	errorHandler := func(val any, err error) {
+		mu.Lock()
+		errors = append(errors, val.(int))
+		mu.Unlock()
+	}
+
+	pool := NewPool(cfg, fn, errorHandler, nil)
+
+	in := make(chan int, 5)
+	ctx := context.Background()
+
+	out := pool.Start(ctx, in, 10)
+
+	in <- 1
+	in <- -1 // Will error
+	in <- 2
+	in <- -2 // Will error
+	in <- 3
+	close(in)
+
+	var results []int
+	for v := range out {
+		results = append(results, v)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+
+	mu.Lock()
+	if len(errors) != 2 {
+		t.Errorf("expected 2 errors, got %d", len(errors))
+	}
+	mu.Unlock()
+}
+
+func TestConfig_Parse_Defaults(t *testing.T) {
+	cfg := Parse(0, 0, 0, 0, 0, 0)
+
+	if cfg.MinWorkers != DefaultMinWorkers {
+		t.Errorf("expected MinWorkers=%d, got %d", DefaultMinWorkers, cfg.MinWorkers)
+	}
+	if cfg.MaxWorkers <= 0 {
+		t.Errorf("expected MaxWorkers > 0, got %d", cfg.MaxWorkers)
+	}
+	if cfg.ScaleDownAfter != DefaultScaleDownAfter {
+		t.Errorf("expected ScaleDownAfter=%v, got %v", DefaultScaleDownAfter, cfg.ScaleDownAfter)
+	}
+	if cfg.ScaleUpCooldown != DefaultScaleUpCooldown {
+		t.Errorf("expected ScaleUpCooldown=%v, got %v", DefaultScaleUpCooldown, cfg.ScaleUpCooldown)
+	}
+	if cfg.ScaleDownCooldown != DefaultScaleDownCooldown {
+		t.Errorf("expected ScaleDownCooldown=%v, got %v", DefaultScaleDownCooldown, cfg.ScaleDownCooldown)
+	}
+	if cfg.CheckInterval != DefaultCheckInterval {
+		t.Errorf("expected CheckInterval=%v, got %v", DefaultCheckInterval, cfg.CheckInterval)
+	}
+}
+
+func TestConfig_Parse_MinGreaterThanMax(t *testing.T) {
+	cfg := Parse(10, 5, 0, 0, 0, 0)
+
+	if cfg.MinWorkers > cfg.MaxWorkers {
+		t.Errorf("MinWorkers (%d) should not exceed MaxWorkers (%d)", cfg.MinWorkers, cfg.MaxWorkers)
+	}
+}

--- a/pipe/processing_benchmark_test.go
+++ b/pipe/processing_benchmark_test.go
@@ -1,0 +1,293 @@
+package pipe
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// BenchmarkProcessing_StaticConcurrency benchmarks processing with static worker count.
+func BenchmarkProcessing_StaticConcurrency(b *testing.B) {
+	benchmarks := []struct {
+		name        string
+		concurrency int
+		items       int
+		workTime    time.Duration
+	}{
+		{"Concurrency1_Items100_Fast", 1, 100, 0},
+		{"Concurrency4_Items100_Fast", 4, 100, 0},
+		{"Concurrency8_Items100_Fast", 8, 100, 0},
+		{"Concurrency1_Items100_Slow", 1, 100, time.Microsecond},
+		{"Concurrency4_Items100_Slow", 4, 100, time.Microsecond},
+		{"Concurrency8_Items100_Slow", 8, 100, time.Microsecond},
+		{"Concurrency4_Items1000_Fast", 4, 1000, 0},
+		{"Concurrency8_Items1000_Fast", 8, 1000, 0},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			workTime := bm.workTime
+			process := func(ctx context.Context, v int) ([]int, error) {
+				if workTime > 0 {
+					time.Sleep(workTime)
+				}
+				return []int{v * 2}, nil
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				in := make(chan int, bm.items)
+				out := startProcessing(context.Background(), in, process, Config{
+					Concurrency: bm.concurrency,
+					BufferSize:  bm.items,
+				})
+
+				// Send all items
+				go func() {
+					for j := 0; j < bm.items; j++ {
+						in <- j
+					}
+					close(in)
+				}()
+
+				// Drain output
+				for range out {
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkProcessing_Autoscale benchmarks processing with autoscaling workers.
+func BenchmarkProcessing_Autoscale(b *testing.B) {
+	benchmarks := []struct {
+		name       string
+		minWorkers int
+		maxWorkers int
+		items      int
+		workTime   time.Duration
+	}{
+		{"Min1Max4_Items100_Fast", 1, 4, 100, 0},
+		{"Min1Max8_Items100_Fast", 1, 8, 100, 0},
+		{"Min2Max8_Items100_Fast", 2, 8, 100, 0},
+		{"Min1Max4_Items100_Slow", 1, 4, 100, time.Microsecond},
+		{"Min1Max8_Items100_Slow", 1, 8, 100, time.Microsecond},
+		{"Min2Max8_Items100_Slow", 2, 8, 100, time.Microsecond},
+		{"Min2Max8_Items1000_Fast", 2, 8, 1000, 0},
+		{"Min4Max16_Items1000_Fast", 4, 16, 1000, 0},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			workTime := bm.workTime
+			process := func(ctx context.Context, v int) ([]int, error) {
+				if workTime > 0 {
+					time.Sleep(workTime)
+				}
+				return []int{v * 2}, nil
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				in := make(chan int, bm.items)
+				out := startProcessing(context.Background(), in, process, Config{
+					Autoscale: &AutoscaleConfig{
+						MinWorkers:        bm.minWorkers,
+						MaxWorkers:        bm.maxWorkers,
+						ScaleUpCooldown:   time.Millisecond,
+						ScaleDownCooldown: time.Millisecond,
+						ScaleDownAfter:    100 * time.Millisecond,
+						CheckInterval:     time.Millisecond,
+					},
+					BufferSize: bm.items,
+				})
+
+				// Send all items
+				go func() {
+					for j := 0; j < bm.items; j++ {
+						in <- j
+					}
+					close(in)
+				}()
+
+				// Drain output
+				for range out {
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkProcessing_Comparison directly compares static vs autoscale for same workload.
+func BenchmarkProcessing_Comparison(b *testing.B) {
+	items := 500
+	workTime := 10 * time.Microsecond
+
+	process := func(ctx context.Context, v int) ([]int, error) {
+		time.Sleep(workTime)
+		return []int{v * 2}, nil
+	}
+
+	b.Run("Static_Concurrency4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, items)
+			out := startProcessing(context.Background(), in, process, Config{
+				Concurrency: 4,
+				BufferSize:  items,
+			})
+
+			go func() {
+				for j := 0; j < items; j++ {
+					in <- j
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+
+	b.Run("Static_Concurrency8", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, items)
+			out := startProcessing(context.Background(), in, process, Config{
+				Concurrency: 8,
+				BufferSize:  items,
+			})
+
+			go func() {
+				for j := 0; j < items; j++ {
+					in <- j
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+
+	b.Run("Autoscale_Min1Max8", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, items)
+			out := startProcessing(context.Background(), in, process, Config{
+				Autoscale: &AutoscaleConfig{
+					MinWorkers:        1,
+					MaxWorkers:        8,
+					ScaleUpCooldown:   time.Millisecond,
+					ScaleDownCooldown: time.Millisecond,
+					ScaleDownAfter:    50 * time.Millisecond,
+					CheckInterval:     time.Millisecond,
+				},
+				BufferSize: items,
+			})
+
+			go func() {
+				for j := 0; j < items; j++ {
+					in <- j
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+
+	b.Run("Autoscale_Min4Max8", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, items)
+			out := startProcessing(context.Background(), in, process, Config{
+				Autoscale: &AutoscaleConfig{
+					MinWorkers:        4,
+					MaxWorkers:        8,
+					ScaleUpCooldown:   time.Millisecond,
+					ScaleDownCooldown: time.Millisecond,
+					ScaleDownAfter:    50 * time.Millisecond,
+					CheckInterval:     time.Millisecond,
+				},
+				BufferSize: items,
+			})
+
+			go func() {
+				for j := 0; j < items; j++ {
+					in <- j
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+}
+
+// BenchmarkProcessing_BurstLoad simulates burst load patterns.
+func BenchmarkProcessing_BurstLoad(b *testing.B) {
+	burstSize := 100
+	bursts := 5
+	workTime := 50 * time.Microsecond
+
+	process := func(ctx context.Context, v int) ([]int, error) {
+		time.Sleep(workTime)
+		return []int{v * 2}, nil
+	}
+
+	b.Run("Static_Concurrency4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, burstSize)
+			out := startProcessing(context.Background(), in, process, Config{
+				Concurrency: 4,
+				BufferSize:  burstSize,
+			})
+
+			go func() {
+				for burst := 0; burst < bursts; burst++ {
+					// Send burst
+					for j := 0; j < burstSize; j++ {
+						in <- j
+					}
+					// Brief pause between bursts
+					time.Sleep(time.Millisecond)
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+
+	b.Run("Autoscale_Min1Max8", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			in := make(chan int, burstSize)
+			out := startProcessing(context.Background(), in, process, Config{
+				Autoscale: &AutoscaleConfig{
+					MinWorkers:        1,
+					MaxWorkers:        8,
+					ScaleUpCooldown:   time.Millisecond,
+					ScaleDownCooldown: 5 * time.Millisecond,
+					ScaleDownAfter:    10 * time.Millisecond,
+					CheckInterval:     time.Millisecond,
+				},
+				BufferSize: burstSize,
+			})
+
+			go func() {
+				for burst := 0; burst < bursts; burst++ {
+					// Send burst
+					for j := 0; j < burstSize; j++ {
+						in <- j
+					}
+					// Brief pause between bursts
+					time.Sleep(time.Millisecond)
+				}
+				close(in)
+			}()
+
+			for range out {
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `AutoscaleConfig` to `pipe.Config` for automatic worker scaling based on load
- Scale up when workers are saturated, scale down after idle timeout
- Configurable min/max workers, cooldowns, and check intervals
- Sensible defaults (1 to NumCPU workers, 30s idle timeout)

## Changes

- `pipe/autoscale.go`: public `AutoscaleConfig` type
- `pipe/internal/autoscale/pool.go`: pool implementation with scaling logic
- `pipe/processing.go`: integration with ProcessPipe
- Design docs in `docs/plans/pipe-autoscaling.md` and `pipe-ordering.md`

## Test Plan

- [x] Unit tests cover scaling behavior and edge cases (646 lines)
- [x] Benchmarks included (293 lines)
- [ ] `make check` passes