### PR TITLE
feat(message/jsonschema): add Registry with middleware-based validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Decoupled from `context.Context`: locals do not appear in `ctx.Value()` lookups
   - `Copy()` clones locals along with attributes
   - Unblocks auth middleware, transaction handling, and tracing adapters
+- **message/jsonschema:** JSON Schema validation for CloudEvents messages
+  - `Registry` for managing schemas by CloudEvents type (eventType → schema)
+  - `RegisterType(v, schema)` derives eventType from Go type via naming strategy
+  - Configurable `SchemaURI` function for custom schema URI schemes (defaults to URN)
+  - Implements `InputRegistry` for automatic instance creation in pipes
+  - `Validate(eventType, data)` validates raw bytes against compiled schemas
+  - `Schema(eventType)` and `Schemas()` for HTTP schema serving
+  - Three validation middleware types:
+    - `NewInputValidationMiddleware` - validates before unmarshaling (fail fast)
+    - `NewOutputValidationMiddleware` - validates after marshaling
+    - `NewValidationMiddleware` - validates proxy scenarios (RawMessage → RawMessage)
+  - Thread-safe for shared use across middleware and pipes
+  - Uses JSON Schema Draft 2020-12 via `santhosh-tekuri/jsonschema/v6`
+  - Separation of concerns: validation separate from marshaling
+  - See ADR 0027 and `examples/07-validating-marshaler` for usage
 
 ### Fixed
 

--- a/docs/adr/0027-json-schema-validation.md
+++ b/docs/adr/0027-json-schema-validation.md
@@ -1,0 +1,290 @@
+# ADR 0027: JSON Schema Validation
+
+**Date:** 2026-02-16
+**Status:** Implemented
+
+## Context
+
+Message validation is essential for event-driven architectures. Go's zero-value semantics create a validation gap: `encoding/json` fills missing required fields with zero values (`""`, `0`, `false`), making it impossible to distinguish between explicitly set zeros and missing fields.
+
+JSON Schema solves this by validating the raw JSON **before** unmarshaling. This catches missing required fields, type mismatches, and constraint violations at the system boundary.
+
+**Requirements:**
+1. Validate CloudEvents message payloads against JSON Schema definitions
+2. Support both typed scenarios (handlers with Go types) and proxy scenarios (no types)
+3. Separate validation concerns from serialization concerns
+4. Integrate with gopipe's middleware pattern
+5. Serve schemas via HTTP for API contract discovery
+
+## Decision
+
+Implement JSON Schema validation through a `Registry` + middleware pattern, separating validation from marshaling.
+
+### Core: Registry
+
+`Registry` provides schema validation by CloudEvents type, with optional Go type tracking:
+
+```go
+type Registry struct {
+    schemas  map[string]*entry          // eventType → schema
+    types    map[string]reflect.Type    // eventType → Go type (optional)
+    reverse  map[reflect.Type]string    // Go type → eventType
+    naming   message.EventTypeNaming
+}
+
+type Config struct {
+    Naming    message.EventTypeNaming              // Default: KebabNaming
+    SchemaURI func(eventType string) string        // Default: urn:gopipe:schema:cloudevents:{eventType}
+}
+
+func NewRegistry(cfg Config) *Registry
+func (r *Registry) RegisterType(v any, schemaJSON string) error
+func (r *Registry) MustRegisterType(v any, schemaJSON string)
+func (r *Registry) Validate(eventType string, data []byte) error
+func (r *Registry) NewInput(eventType string) any  // InputRegistry
+func (r *Registry) Schema(eventType string) json.RawMessage
+func (r *Registry) Schemas() json.RawMessage
+```
+
+**Key properties:**
+- Validates by **CloudEvents type**, not Go type
+- RegisterType uses naming strategy to derive eventType automatically
+- Implements InputRegistry for UnmarshalPipe support
+- Thread-safe for shared use across middleware/pipes
+- **No marshaling** - pure validation only
+
+### Validation: Middleware
+
+Three middleware types for different pipeline stages:
+
+```go
+// Proxy: RawMessage → RawMessage (no unmarshaling)
+func NewValidationMiddleware(registry *Registry)
+    middleware.Middleware[*RawMessage, *RawMessage]
+
+// Pre-validation: Before unmarshaling (fail fast)
+func NewInputValidationMiddleware(registry *Registry)
+    middleware.Middleware[*RawMessage, *Message]
+
+// Post-validation: After marshaling (validate output)
+func NewOutputValidationMiddleware(registry *Registry)
+    middleware.Middleware[*Message, *RawMessage]
+```
+
+### Marshaling: Standard JSON
+
+Use standard `message.NewJSONMarshaler()` for serialization. Validation is separate:
+
+```go
+marshaler := message.NewJSONMarshaler()
+unmarshalPipe := message.NewUnmarshalPipe(registry, marshaler, cfg)
+unmarshalPipe.Use(jsonschema.NewInputValidationMiddleware(registry))
+```
+
+## Usage Patterns
+
+### Pattern 1: Typed Handlers
+
+```go
+registry := jsonschema.NewRegistry(jsonschema.Config{
+    Naming: message.KebabNaming,
+})
+registry.MustRegisterType(CreateOrder{}, orderSchema)
+// Derives "create.order" automatically
+
+marshaler := message.NewJSONMarshaler()
+unmarshalPipe := message.NewUnmarshalPipe(registry, marshaler, cfg)
+unmarshalPipe.Use(jsonschema.NewInputValidationMiddleware(registry))
+```
+
+### Pattern 2: Proxy (No Types)
+
+For proxy scenarios, explicit `Register(eventType, schema)` can be added later. For now, proxy scenarios can define minimal Go types purely for validation without actual unmarshaling.
+
+### Pattern 3: Schema Serving
+
+```go
+// Individual schema by CloudEvents type
+mux.HandleFunc("GET /schema/{type}", func(w http.ResponseWriter, r *http.Request) {
+    eventType := r.PathValue("type")
+    schema := registry.Schema(eventType)  // e.g., "create.order"
+    w.Header().Set("Content-Type", "application/schema+json")
+    w.Write(schema)
+})
+
+// Catalog of all schemas
+mux.HandleFunc("GET /schemas", func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/schema+json")
+    w.Write(registry.Schemas())  // Composed $defs document
+})
+```
+
+## Consequences
+
+### Benefits
+
+1. **Pure separation** - Validation and marshaling are independent concerns
+2. **Middleware pattern** - Idiomatic gopipe composition
+3. **Proxy support** - Can validate without Go types (future: explicit Register)
+4. **CloudEvents-native** - Validation by eventType, not Go types
+5. **Schema serving** - Registry provides both individual and catalog endpoints
+6. **Fail fast** - Pre-validation catches errors before unmarshaling
+7. **Type-safe** - Go type tracking via RegisterType for handlers
+8. **Reusable** - Single Registry shared across middleware and pipes
+
+### Breaking Changes
+
+- New package: `message/jsonschema`
+- Requires JSON Schema Draft 2020-12 format
+- Depends on `github.com/santhosh-tekuri/jsonschema/v6`
+
+### Limitations
+
+1. **RegisterType only** - Explicit `Register(eventType, schema)` deferred to keep initial API focused
+2. **Single schema per type** - One eventType maps to one schema (versioning handled via new types)
+3. **Validation overhead** - Additional parsing/validation on hot path (mitigated by pre-compilation)
+
+### Design Decisions
+
+**Why Registry, not Marshaler?**
+- "Marshaler" implies serialization responsibility (Marshal/Unmarshal methods)
+- Registry focuses on validation only, avoiding conceptual coupling
+- Standard JSON marshaling is separate (message.NewJSONMarshaler)
+
+**Why RegisterType only initially?**
+- Simpler API surface during initial release
+- Justifies InputRegistry implementation (needs Go types)
+- Explicit Register(eventType, schema) can be added incrementally
+- Covers 90% of use cases (typed handlers)
+
+**Why middleware instead of Marshaler.Unmarshal validation?**
+- Middleware is composable across different pipe stages
+- Allows pre-validation before unmarshaling (fail fast)
+- Separates concerns: validation vs serialization
+- Enables proxy scenarios without unmarshaling
+
+**Why three middleware types?**
+- Different pipe stages have different signatures
+- InputValidationMiddleware validates before unmarshaling
+- OutputValidationMiddleware validates after marshaling
+- ValidationMiddleware for proxy scenarios (RawMessage → RawMessage)
+- Each serves a distinct use case
+
+**Why CloudEvents type, not Go type?**
+- CloudEvents type is the runtime identity
+- Same Go type might represent different event versions
+- Proxy scenarios have no Go types
+- Aligns with message routing and InputRegistry
+
+**Why `santhosh-tekuri/jsonschema/v6`?**
+
+| Library | Draft 2020-12 | Maintained | Notes |
+|---|---|---|---|
+| `santhosh-tekuri/jsonschema/v6` | Yes | Active | Full spec compliance, compile-once/validate-many |
+| `xeipuuv/gojsonschema` | No | Abandoned (~2020) | Former de facto standard, stuck on Draft 7 |
+| `qri-io/jsonschema` | Yes | Low activity | Small community, limited adoption |
+| `google/go-jsonschema` | N/A | Active | Code generator (structs from schemas), not a runtime validator |
+
+`santhosh-tekuri/jsonschema/v6` is the only actively maintained Go library with full Draft 2020-12 support. It compiles schemas upfront for efficient repeated validation, which fits the Registry's compile-once pattern.
+
+## Implementation Notes
+
+### Schema URI Convention
+
+Schemas are compiled with URIs derived from CloudEvents types. By default:
+
+```go
+func defaultSchemaURI(eventType string) string {
+    return fmt.Sprintf("urn:gopipe:schema:cloudevents:%s", eventType)
+}
+```
+
+Custom URI schemes can be configured for HTTP-based schemas or organization-specific naming:
+
+```go
+registry := jsonschema.NewRegistry(jsonschema.Config{
+    SchemaURI: func(eventType string) string {
+        return fmt.Sprintf("https://api.example.com/schemas/%s", eventType)
+    },
+})
+```
+
+The URI is used internally by the JSON Schema compiler and doesn't need to be resolvable. However, using HTTP URLs allows schemas to be published at those locations for external tooling or CloudEvents `dataschema` attribute references.
+
+### Thread Safety
+
+Registry is thread-safe via RWMutex, allowing:
+- Concurrent validation across goroutines
+- Shared Registry between middleware and pipes
+- One-time registration at startup, many readers during runtime
+
+### Strict Validation
+
+If no schema is registered for an eventType, `Validate()` returns an error. This prevents unvalidated messages from silently passing through due to typos in event types or missing registrations.
+
+## Alternatives Considered
+
+### Alternative 1: Validation in Marshaler
+
+Keep validation coupled to Marshal/Unmarshal methods:
+
+```go
+type Marshaler struct { ... }
+func (m *Marshaler) Unmarshal(data []byte, v any) error {
+    // Validate, then unmarshal
+}
+```
+
+**Rejected because:**
+- Couples validation with serialization (violates single responsibility)
+- Doesn't support proxy scenarios (need types to marshal)
+- Less flexible than middleware composition
+- Harder to validate at different pipeline stages
+
+### Alternative 2: Single Middleware Type
+
+Use `Message` everywhere instead of RawMessage/Message distinction:
+
+```go
+type ValidationMiddleware = Middleware[*Message, *Message]
+```
+
+**Deferred because:**
+- Requires broader architectural change (Message unification)
+- Current RawMessage vs Message distinction is intentional
+- Can be revisited later if Message types are unified
+- Three middleware types work well with current architecture
+
+### Alternative 3: Engine Integration
+
+Build validation directly into Engine:
+
+```go
+engine := message.NewEngine(message.EngineConfig{
+    Validator: jsonschema.NewValidator(...),
+})
+```
+
+**Rejected because:**
+- Less flexible than middleware approach
+- Couples validation to Engine (not all pipes use Engine)
+- Middleware is more composable and testable
+- Users can add validation exactly where needed
+
+## Links
+
+- Related: ADR 0021 (Marshaler and NamingStrategy)
+- Related: ADR 0022 (Message Package Redesign)
+- Related: ADR 0024 (HTTP CloudEvents Adapter)
+- Plan: [validating-marshaler-example-enhancement.md](../plans/validating-marshaler-example-enhancement.md)
+- Implementation: `message/jsonschema/registry.go`
+- Example: `examples/07-validating-marshaler/`
+
+## Future Enhancements
+
+1. **Explicit Register** - Add `Register(eventType, schema)` for pure proxy scenarios
+2. **Schema versioning** - Convention for versioned schemas (e.g., `order.created.v2`)
+3. **Custom validators** - Plugin system for domain-specific validation
+4. **Validation caching** - Cache validation results for identical payloads
+5. **Schema references** - Support `$ref` across registered schemas
+6. **Metrics** - Validation success/failure counters for observability

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ See [ADR Procedures](../procedures/adr.md) for details.
 | [0023](0023-engine-simplification.md) | Engine Simplification | Implemented |
 | [0024](0024-http-cloudevents-adapter.md) | HTTP CloudEvents Adapter Design | Implemented |
 | [0025](0025-message-context-values.md) | Message Context for In-Process Values | Proposed |
+| [0027](0027-json-schema-validation.md) | JSON Schema Validation | Implemented |
 | [0026](0026-acking-middleware-outermost.md) | Acking Middleware Outermost | Proposed |
 
 ## History

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -35,6 +35,7 @@ Historical plans from the message package development are in [archive/](archive/
 | [0011](archive/0011-named-pools.md) | Named Pools | Complete |
 | [0012](archive/0012-engine-simplification.md) | Engine Simplification | Complete |
 | [0013](archive/0013-http-cloudevents-adapter.md) | HTTP CloudEvents Adapter | Complete |
+| [validating-marshaler-example-enhancement](validating-marshaler-example-enhancement.md) | Validating Marshaler Example Enhancement | Complete |
 
 ## Creating New Plans
 

--- a/docs/plans/validating-marshaler-example-enhancement.md
+++ b/docs/plans/validating-marshaler-example-enhancement.md
@@ -1,0 +1,341 @@
+# Plan: Validating Marshaler Example Enhancement
+
+**Status:** Complete
+**Related ADRs:** [0022](../adr/0022-message-package-redesign.md), [0024](../adr/0024-http-cloudevents-adapter.md), [0027](../adr/0027-json-schema-validation.md)
+
+## Overview
+
+Enhance the JSON Schema validation example to demonstrate real-world HTTP CloudEvents patterns with proper command/event separation and schema serving capabilities.
+
+## Context
+
+The branch `claude/explore-message-validation-BnHzL` introduces JSON Schema validation via `message/jsonschema` (Registry + Middleware pattern). The current example (07-validating-marshaler) demonstrates validation but lacks real-world patterns like HTTP ingestion, schema discovery endpoints, and proper CQRS boundaries.
+
+CloudEvents best practices recommend:
+- Serving schemas at HTTP endpoints (referenced by `dataschema` attribute)
+- Command/event separation (not domain models)
+- Schema versioning via URI changes
+- Schema discovery for consumers/brokers
+
+## Current Implementation Analysis
+
+### Library Implementation (`message/jsonschema/registry.go`)
+- ✅ Schema per CloudEvents type via `map[string]*entry`
+- ✅ Uses JSON Schema Draft 2020-12 with `santhosh-tekuri/jsonschema/v6`
+- ✅ `Schema()` / `Schemas()` methods return `json.RawMessage` for serving
+- ✅ Comprehensive test coverage in `registry_test.go`
+- ✅ Validation via middleware (input/output/proxy), decoupled from marshaling
+- ✅ Implements `InputRegistry` for automatic type creation in pipes
+
+### Example Limitations
+- ❌ No HTTP server (hardcoded in-memory test messages)
+- ❌ Uses domain model `CreateOrder` instead of command/event separation
+- ❌ No schema serving endpoints
+- ❌ No demonstration of channel/pipe primitives
+- ❌ Missing real-world validation failure scenarios
+
+## Goals
+
+1. Demonstrate HTTP CloudEvents server accepting validated commands
+2. Show command → event transformation with separate types
+3. Serve schemas at HTTP endpoints following CloudEvents `dataschema` pattern
+4. Use gopipe channel/pipe primitives for message flow
+5. Keep example minimal but production-ready
+
+## CloudEvents Best Practices (Research Summary)
+
+### Schema Serving Pattern
+- **AWS EventBridge**: Schema registry with URI references
+- **Google Cloud Eventarc**: `dataschema` points to HTTP JSON Schema endpoints
+- **CloudEvents Spec**: Incompatible schema versions should use different URIs
+
+### Key Attributes
+- `dataschema` (optional): URI pointing to the schema for `data` field
+- `datacontenttype`: Media type (e.g., `application/json`)
+- Schema URIs should be HTTP endpoints returning JSON Schema documents
+
+### Versioning Strategy
+- Different schema versions = different URIs
+- No mandated versioning pattern in spec
+- Recommended: Separate Go types per version (e.g., `OrderCreatedV1`, `OrderCreatedV2`)
+
+**Sources:**
+- [CloudEvents Specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)
+- [CloudEvents JSON Format](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)
+- [Azure Event Grid CloudEvents](https://learn.microsoft.com/en-us/azure/event-grid/cloud-event-schema)
+- [Google Cloud Eventarc](https://cloud.google.com/eventarc/docs/cloudevents-json)
+- [AWS EventBridge CloudEvents](https://aws.amazon.com/blogs/compute/sending-and-receiving-cloudevents-with-amazon-eventbridge/)
+
+## Tasks
+
+### Task 1: Define Command and Event Types
+
+**Goal:** Demonstrate CQRS pattern with separate input/output types
+
+**Implementation:**
+```go
+// CreateOrderCommand - input command (HTTP boundary)
+type CreateOrderCommand struct {
+    OrderID string  `json:"order_id"`
+    Amount  float64 `json:"amount"`
+}
+
+const createOrderCommandSchema = `{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "order_id": { "type": "string", "minLength": 1 },
+        "amount":   { "type": "number", "exclusiveMinimum": 0 }
+    },
+    "required": ["order_id", "amount"],
+    "additionalProperties": false
+}`
+
+// OrderCreatedEvent - output event (downstream consumers)
+type OrderCreatedEvent struct {
+    OrderID   string    `json:"order_id"`
+    Status    string    `json:"status"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+const orderCreatedEventSchema = `{...}`
+```
+
+**Files to Modify:**
+- `examples/07-validating-marshaler/main.go` - Replace domain model with command/event
+
+**Acceptance Criteria:**
+- [x] Command type represents user intent (input boundary)
+- [x] Event type represents fact (output boundary)
+- [x] Both types have strict JSON Schema definitions
+- [x] Schemas registered at startup
+
+### Task 2: HTTP Server with CloudEvents Ingestion
+
+**Goal:** Accept CloudEvents via HTTP (binary or structured mode)
+
+**Implementation:**
+```go
+func main() {
+    ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+    defer cancel()
+
+    // Setup marshaler with schemas
+    marshaler := jsonschema.NewMarshaler()
+    marshaler.MustRegister(CreateOrderCommand{}, createOrderCommandSchema)
+    marshaler.MustRegister(OrderCreatedEvent{}, orderCreatedEventSchema)
+
+    // Setup engine
+    engine := message.NewEngine(message.EngineConfig{
+        Marshaler: marshaler,
+        ErrorHandler: func(msg *message.Message, err error) {
+            log.Printf("❌ Validation failed: %v", err)
+        },
+    })
+
+    // HTTP subscriber for commands
+    subscriber := cehttp.NewSubscriber(cehttp.SubscriberConfig{BufferSize: 100})
+    inputCh, _ := subscriber.Subscribe(ctx)
+    engine.AddRawInput("http-commands", nil, inputCh)
+
+    // Command handler: CreateOrderCommand → OrderCreatedEvent
+    engine.AddHandler("process-order", nil, message.NewCommandHandler(
+        func(ctx context.Context, cmd CreateOrderCommand) ([]OrderCreatedEvent, error) {
+            log.Printf("✅ Processing order: %s ($%.2f)", cmd.OrderID, cmd.Amount)
+            return []OrderCreatedEvent{{
+                OrderID:   cmd.OrderID,
+                Status:    "confirmed",
+                CreatedAt: time.Now(),
+            }}, nil
+        },
+        message.CommandHandlerConfig{
+            Source: "/order-processor",
+            Naming: message.KebabNaming,
+        },
+    ))
+
+    // Start engine
+    engineDone, _ := engine.Start(ctx)
+
+    // HTTP server
+    mux := http.NewServeMux()
+    mux.Handle("POST /events", subscriber)
+    // ... schema endpoints (Task 3)
+}
+```
+
+**Files to Modify:**
+- `examples/07-validating-marshaler/main.go` - Add HTTP server with CloudEvents subscriber
+
+**Acceptance Criteria:**
+- [x] HTTP server listens on `:8080`
+- [x] Accepts CloudEvents in binary mode (headers: `Ce-*`)
+- [x] Accepts CloudEvents in structured mode (`Content-Type: application/cloudevents+json`)
+- [x] Valid commands processed successfully
+- [x] Invalid commands rejected with clear error messages
+
+### Task 3: Schema Serving Endpoints
+
+**Goal:** Serve JSON schemas at HTTP endpoints for discovery
+
+**Implementation:**
+```go
+// Schema catalog endpoint
+mux.HandleFunc("GET /schemas", func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json")
+    catalog := map[string]json.RawMessage{
+        "create-order-command": marshaler.Schema(CreateOrderCommand{}),
+        "order-created-event":  marshaler.Schema(OrderCreatedEvent{}),
+    }
+    json.NewEncoder(w).Encode(catalog)
+})
+
+// Individual schema endpoint
+mux.HandleFunc("GET /schema/{type}", func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/schema+json")
+
+    var schema json.RawMessage
+    switch r.PathValue("type") {
+    case "create-order-command":
+        schema = marshaler.Schema(CreateOrderCommand{})
+    case "order-created-event":
+        schema = marshaler.Schema(OrderCreatedEvent{})
+    default:
+        http.NotFound(w, r)
+        return
+    }
+
+    if schema == nil {
+        http.NotFound(w, r)
+        return
+    }
+
+    w.Write(schema)
+})
+```
+
+**Files to Modify:**
+- `examples/07-validating-marshaler/main.go` - Add schema endpoints
+
+**Acceptance Criteria:**
+- [x] `GET /schemas` returns catalog of all schemas
+- [x] `GET /schema/{type}` returns individual JSON Schema
+- [x] Returns 404 for unknown schema types
+- [x] Content-Type headers set correctly
+
+### Task 4: Channel/Pipe Primitives for stdout
+
+**Goal:** Demonstrate gopipe channel/pipe usage for event printing
+
+**Implementation:**
+```go
+// Output events to stdout using pipe
+outputCh, _ := engine.AddRawOutput("events", nil)
+
+printer := pipe.NewSinkPipe(func(ctx context.Context, raw *message.RawMessage) error {
+    var event OrderCreatedEvent
+    json.Unmarshal(raw.Data, &event)
+    log.Printf("📤 Event: %s | order=%s status=%s",
+        raw.Type(), event.OrderID, event.Status)
+    return nil
+}, pipe.Config{Concurrency: 1})
+
+printer.Pipe(ctx, outputCh)
+```
+
+**Files to Modify:**
+- `examples/07-validating-marshaler/main.go` - Add pipe-based stdout printer
+
+**Acceptance Criteria:**
+- [x] Uses `pipe.NewSinkPipe` for stdout printing
+- [x] Events printed in readable format
+- [x] Demonstrates channel-based flow separation
+
+### Task 5: Validation Demonstration
+
+**Goal:** Show clear validation success/failure scenarios
+
+**Implementation:**
+Include curl examples in startup message and comments:
+
+```bash
+# Valid request
+curl -X POST http://localhost:8080/events \
+  -H "Ce-Specversion: 1.0" -H "Ce-Id: 1" \
+  -H "Ce-Type: create-order-command" -H "Ce-Source: /client" \
+  -d '{"order_id":"ORD-001","amount":100}'
+
+# Invalid: missing required field
+curl -X POST http://localhost:8080/events \
+  -H "Ce-Specversion: 1.0" -H "Ce-Id: 2" \
+  -H "Ce-Type: create-order-command" -H "Ce-Source: /client" \
+  -d '{"order_id":"ORD-002"}'
+
+# Invalid: wrong type
+curl -X POST http://localhost:8080/events \
+  -H "Ce-Specversion: 1.0" -H "Ce-Id: 3" \
+  -H "Ce-Type: create-order-command" -H "Ce-Source: /client" \
+  -d '{"order_id":"ORD-003","amount":"free"}'
+
+# Invalid: empty string (minLength violation)
+curl -X POST http://localhost:8080/events \
+  -H "Ce-Specversion: 1.0" -H "Ce-Id: 4" \
+  -H "Ce-Type: create-order-command" -H "Ce-Source: /client" \
+  -d '{"order_id":"","amount":50}'
+```
+
+**Files to Modify:**
+- `examples/07-validating-marshaler/main.go` - Add usage instructions and comments
+
+**Acceptance Criteria:**
+- [x] Example includes curl commands in comments/output
+- [x] Valid request shows successful processing
+- [x] Invalid requests show clear error messages
+- [x] Error handler logs validation failures with context
+
+## Implementation Order
+
+```
+Task 1 (Command/Event Types)
+    ↓
+Task 2 (HTTP Server)
+    ↓
+Task 3 (Schema Endpoints) ← Task 4 (Pipe stdout)
+    ↓
+Task 5 (Documentation)
+```
+
+Tasks 3 and 4 can be implemented in parallel after Task 2.
+
+## Files to Create/Modify
+
+| File | Changes |
+|------|---------|
+| `examples/07-validating-marshaler/main.go` | Complete rewrite with HTTP server, schema endpoints, pipes |
+
+**No changes to library code** - the existing `jsonschema.Registry` + middleware already supports all required functionality.
+
+**Note:** The actual implementation uses manual pipe composition (`UnmarshalPipe` → `Router` → `MarshalPipe` → `SinkPipe`) instead of the Engine-based approach shown in Task 2's code example. This better demonstrates the low-level pipe primitives.
+
+## Acceptance Criteria
+
+- [x] All tasks completed
+- [x] Example runs with `go run ./examples/07-validating-marshaler`
+- [x] HTTP server accepts valid CloudEvents and processes them
+- [x] Invalid CloudEvents rejected with clear validation errors
+- [x] Schema catalog endpoint returns all schemas
+- [x] Individual schema endpoints return JSON Schema documents
+- [x] Uses pipe primitives for stdout printing
+- [x] Demonstrates command/event separation pattern
+- [x] Example is minimal (~195 lines) but production-ready
+- [x] Comments include curl commands for testing
+
+## Verification Steps
+
+1. **Run example**: `go run ./examples/07-validating-marshaler`
+2. **Valid request**: Should process and emit OrderCreatedEvent
+3. **Invalid requests**: Should log validation errors (3 test cases)
+4. **Schema catalog**: `curl http://localhost:8080/schemas` returns JSON
+5. **Individual schema**: `curl http://localhost:8080/schema/create-order-command` returns JSON Schema
+6. **Structured mode**: Test with full CloudEvents JSON payload
+7. **Shutdown**: Ctrl+C should gracefully shutdown server and engine

--- a/docs/plans/validation-marshaling-separation.decisions.md
+++ b/docs/plans/validation-marshaling-separation.decisions.md
@@ -1,0 +1,347 @@
+# Validation vs. Marshaling Separation - Design Evolution
+
+**Status:** Resolved — Option A implemented (Pure Separation via Registry + Middleware)
+**Related Plan:** validating-marshaler-example-enhancement.md
+**Related ADR:** [0027](../adr/0027-json-schema-validation.md)
+
+## Context
+
+Current `message/jsonschema` implementation couples validation with Go type marshaling:
+
+```go
+// Must define Go type
+type CreateOrder struct { OrderID string }
+
+// Register schema WITH Go type
+marshaler.MustRegister(CreateOrder{}, schema)
+
+// Validation happens during marshal/unmarshal
+marshaler.Unmarshal(data, &order)  // validates + deserializes
+```
+
+**Problem:** Proxy use case needs validation WITHOUT Go types:
+
+```
+HTTP → validate → AMQP
+  ↓                 ↓
+RawMessage     RawMessage
+
+No handler, no Go types - just validate bytes and forward.
+```
+
+## Options Considered
+
+### Option A: Validation Middleware (Pure Separation)
+
+Extract validation into standalone middleware:
+
+```go
+// Registry: CloudEvents type → schema (no Go types)
+type Registry struct {
+    schemas map[string]*compiledSchema  // eventType → schema
+}
+
+func (r *Registry) Register(eventType string, schemaJSON string)
+func (r *Registry) Validate(eventType string, data []byte) error
+func (r *Registry) Schema(eventType string) json.RawMessage
+func (r *Registry) Schemas() json.RawMessage
+
+// Middleware for RawMessage validation
+func NewValidationMiddleware(registry *Registry) middleware.Middleware[*RawMessage, *RawMessage] {
+    return func(next ProcessFunc) ProcessFunc {
+        return func(ctx context.Context, msg *RawMessage) (*RawMessage, error) {
+            if err := registry.Validate(msg.Type(), msg.Data); err != nil {
+                return nil, fmt.Errorf("validation: %w", err)
+            }
+            return next(ctx, msg)
+        }
+    }
+}
+
+// Usage: Proxy
+subscriber := http.NewSubscriber(...)
+rawInput, _ := subscriber.Subscribe(ctx)
+
+// Add validation middleware
+validator := jsonschema.NewRegistry()
+validator.Register("order.created", orderSchema)
+validator.Register("order.cancelled", cancelSchema)
+
+validationMW := jsonschema.NewValidationMiddleware(validator)
+
+// Pipe: input → validate → output (no types!)
+pipe := pipe.NewPassthroughPipe(pipe.Config{})
+pipe.Use(validationMW)
+validated, _ := pipe.Pipe(ctx, rawInput)
+
+publisher := amqp.NewPublisher(...)
+publisher.Publish(ctx, validated)
+
+// Usage: With types (for handlers)
+marshaler := jsonschema.NewMarshaler(jsonschema.Config{
+    Registry: validator,  // Share registry!
+    Naming:   message.KebabNaming,
+})
+marshaler.RegisterType(CreateOrder{})  // Links Go type to "order.created"
+```
+
+**Pros:**
+- ✅ Pure separation: validation ≠ marshaling
+- ✅ Supports proxy use case (no Go types needed)
+- ✅ Middleware is idiomatic gopipe pattern
+- ✅ Registry is reusable (middleware + marshaler share schemas)
+- ✅ Composable - add validation at any pipeline stage
+- ✅ Can validate raw bytes before deciding to unmarshal
+
+**Cons:**
+- ❌ More components (Registry, Marshaler, Middleware)
+- ❌ Schema registration requires explicit eventType string (no type derivation)
+- ❌ Less type-safe when used without Go types
+- ❌ Breaking change to existing API
+
+### Option B: Keep Current Design (Status Quo)
+
+Keep validation inside Marshaler, proxy must define dummy types:
+
+```go
+// Proxy workaround
+type OrderCreated struct{}  // Empty type just for validation
+type OrderCancelled struct{}
+
+marshaler := jsonschema.NewMarshaler(jsonschema.Config{})
+marshaler.MustRegister(OrderCreated{}, orderSchema)
+marshaler.MustRegister(OrderCancelled{}, cancelSchema)
+
+// Validate by round-trip
+var dummy OrderCreated
+if err := marshaler.Unmarshal(msg.Data, &dummy); err != nil {
+    return fmt.Errorf("validation: %w", err)
+}
+// Ignore dummy, forward msg as-is
+```
+
+**Pros:**
+- ✅ No breaking changes
+- ✅ Single component (Marshaler)
+- ✅ Type-safe when used with real handlers
+- ✅ Automatic type derivation via naming
+
+**Cons:**
+- ❌ Requires dummy types for proxy use case
+- ❌ Wasteful unmarshaling just for validation
+- ❌ Validation tightly coupled to serialization
+- ❌ Can't validate without defining Go types
+- ❌ Not idiomatic for proxy pattern
+
+### Option C: Hybrid (Recommended)
+
+Provide both Registry (core) and Marshaler (typed wrapper):
+
+```go
+// Core: Registry (CloudEvents type → schema)
+type Registry struct {
+    mu       sync.RWMutex
+    compiler *jschema.Compiler
+    schemas  map[string]*entry  // eventType → schema
+}
+
+func NewRegistry() *Registry
+func (r *Registry) Register(eventType string, schemaJSON string) error
+func (r *Registry) MustRegister(eventType string, schemaJSON string)
+func (r *Registry) Validate(eventType string, data []byte) error
+func (r *Registry) Schema(eventType string) json.RawMessage
+func (r *Registry) Schemas() json.RawMessage  // Composed catalog
+
+// Middleware: Validates RawMessage using Registry
+func NewValidationMiddleware(registry *Registry) middleware.Middleware[*RawMessage, *RawMessage]
+
+// Marshaler: Adds Go type mapping on top of Registry
+type Marshaler struct {
+    registry *Registry
+    types    map[string]reflect.Type     // eventType → Go type
+    reverse  map[reflect.Type]string     // Go type → eventType
+    naming   message.EventTypeNaming
+}
+
+func NewMarshaler(cfg Config) *Marshaler {
+    return &Marshaler{
+        registry: cfg.Registry,  // Share or create new
+        types:    make(map[string]reflect.Type),
+        reverse:  make(map[reflect.Type]string),
+        naming:   cfg.Naming,
+    }
+}
+
+// Register Go type (derives eventType via naming)
+func (m *Marshaler) Register(v any, schemaJSON string) error {
+    t := elemType(v)
+    eventType := m.naming.EventType(t)
+
+    // Register schema in Registry
+    if err := m.registry.Register(eventType, schemaJSON); err != nil {
+        return err
+    }
+
+    // Map Go type ↔ eventType
+    m.types[eventType] = t
+    m.reverse[t] = eventType
+    return nil
+}
+
+// Unmarshal: validates via Registry, then deserializes
+func (m *Marshaler) Unmarshal(data []byte, v any) error {
+    t := elemType(v)
+    eventType, ok := m.reverse[t]
+    if !ok {
+        return json.Unmarshal(data, v)  // No schema, pass through
+    }
+
+    // Validate using Registry
+    if err := m.registry.Validate(eventType, data); err != nil {
+        return fmt.Errorf("validation: %w", err)
+    }
+
+    return json.Unmarshal(data, v)
+}
+
+// Marshal: serializes, then validates via Registry
+func (m *Marshaler) Marshal(v any) ([]byte, error) {
+    data, err := json.Marshal(v)
+    if err != nil {
+        return nil, err
+    }
+
+    t := elemType(v)
+    eventType, ok := m.reverse[t]
+    if !ok {
+        return data, nil  // No schema, pass through
+    }
+
+    if err := m.registry.Validate(eventType, data); err != nil {
+        return nil, fmt.Errorf("validation: %w", err)
+    }
+
+    return data, nil
+}
+
+// Schema methods delegate to Registry
+func (m *Marshaler) Schema(v any) json.RawMessage {
+    if eventType, ok := m.reverse[elemType(v)]; ok {
+        return m.registry.Schema(eventType)
+    }
+    return nil
+}
+
+func (m *Marshaler) Schemas() json.RawMessage {
+    return m.registry.Schemas()
+}
+
+// NewInput: InputRegistry interface
+func (m *Marshaler) NewInput(eventType string) any {
+    if t, ok := m.types[eventType]; ok {
+        return reflect.New(t).Interface()
+    }
+    return nil
+}
+```
+
+**Usage Patterns:**
+
+```go
+// Pattern 1: Proxy (no types)
+registry := jsonschema.NewRegistry()
+registry.MustRegister("order.created", orderSchema)
+registry.MustRegister("order.cancelled", cancelSchema)
+
+validator := jsonschema.NewValidationMiddleware(registry)
+pipe := pipe.NewPassthroughPipe(pipe.Config{})
+pipe.Use(validator)
+validated, _ := pipe.Pipe(ctx, rawInput)
+publisher.Publish(ctx, validated)
+
+// Pattern 2: Handlers (with types, shared registry)
+marshaler := jsonschema.NewMarshaler(jsonschema.Config{
+    Registry: registry,  // ✅ Share schemas!
+    Naming:   message.KebabNaming,
+})
+marshaler.Register(CreateOrder{}, orderSchema)  // Links type to "order.created"
+
+engine := message.NewEngine(message.EngineConfig{
+    Marshaler: marshaler,
+})
+
+// Pattern 3: Isolated (Marshaler creates its own Registry)
+marshaler := jsonschema.NewMarshaler(jsonschema.Config{
+    Naming: message.KebabNaming,
+})
+marshaler.Register(CreateOrder{}, orderSchema)
+// marshaler.registry is internal
+```
+
+**Pros:**
+- ✅ Best of both worlds
+- ✅ Registry handles core validation logic (type-agnostic)
+- ✅ Marshaler adds type-safety layer
+- ✅ Middleware supports proxy pattern
+- ✅ Shared Registry between middleware and Marshaler
+- ✅ Backward compatible API (Marshaler still works the same)
+- ✅ Schema endpoints can use Registry directly
+
+**Cons:**
+- ⚠️ Two public types (Registry + Marshaler) - more API surface
+- ⚠️ Need clear docs on when to use which
+
+## Resolution
+
+**Option A (Pure Separation)** was implemented, which turned out simpler than the originally recommended Option C:
+
+- **No `jsonschema.Marshaler` wrapper** — marshaling uses standard `message.NewJSONMarshaler()`
+- **Registry handles everything**: validation, Go type tracking, `InputRegistry`, schema serving
+- **Three middleware types** for different pipe stages (input, output, proxy)
+- **`RegisterType(v, schema)`** combines schema + Go type registration (Option A from Q2)
+
+The Option C `Marshaler` wrapper was unnecessary because:
+1. Registry already tracks Go types via `RegisterType` (no need for separate Marshaler layer)
+2. Standard `message.NewJSONMarshaler()` handles serialization (no validation coupling needed)
+3. Middleware handles validation at the pipe level (no need for marshal-time validation)
+
+### Actual File Structure
+
+```
+message/jsonschema/
+├── registry.go           # Core: eventType → schema validation + Go type tracking + InputRegistry
+├── middleware.go          # Three middleware types for input/output/proxy validation
+└── registry_test.go      # Comprehensive tests
+```
+
+## Resolved Questions
+
+1. **Should Registry be in a separate package?**
+   → No. Stayed in `message/jsonschema`. Single package is sufficient.
+
+2. **Should Register accept schemaJSON, or just link types?**
+   → Option A: `RegisterType(v, schema)` registers both together. Explicit `Register(eventType, schema)` without Go types deferred as future enhancement.
+
+3. **Should we provide pre-composed middleware?**
+   → Yes: three middleware constructors (`NewValidationMiddleware`, `NewInputValidationMiddleware`, `NewOutputValidationMiddleware`), each taking `*Registry`.
+
+## Benefits for gopipe
+
+1. **Separation of concerns**: Validation ≠ marshaling (fully decoupled)
+2. **Proxy pattern**: Can validate without Go types (future: explicit `Register`)
+3. **Middleware**: Idiomatic gopipe composition
+4. **CloudEvents-native**: Registry uses eventType, not Go types
+5. **Schema serving**: Individual + catalog endpoints via `Schema()` / `Schemas()`
+6. **InputRegistry**: Registry implements it for automatic type creation in pipes
+
+## Trade-offs
+
+### Simplicity vs. Flexibility
+- Only `RegisterType` (needs Go types), no `Register(eventType, schema)` yet
+- Proxy pattern requires minimal Go types for now
+
+**Mitigation**: `Register(eventType, schema)` can be added incrementally
+
+### API Surface
+- One public type (`Registry`) + three middleware constructors
+- Simpler than originally planned Option C (which had Registry + Marshaler)

--- a/examples/07-validating-marshaler/main.go
+++ b/examples/07-validating-marshaler/main.go
@@ -1,0 +1,195 @@
+// Example: HTTP service with JSON Schema validation using middleware.
+//
+// Demonstrates manual pipeline composition with jsonschema validation middleware.
+// This example shows the low-level pipe primitives instead of using the Engine.
+//
+// Pipeline:
+//   HTTP → UnmarshalPipe+ValidationMW → Router → MarshalPipe+ValidationMW → stdout
+//
+// CloudEvents defines the envelope contract (type, source, id).
+// JSON Schema defines the payload data contract (what's inside "data").
+// Together they provide a full event-driven API spec.
+//
+//   - POST /events         — CloudEvents endpoint (binary or structured mode)
+//   - GET  /schemas         — JSON Schema catalog for all registered types
+//   - GET  /schemas/{type}  — Individual JSON Schema by type name
+//
+// Run:
+//
+//	go run ./examples/07-validating-marshaler
+//
+// Valid request (binary mode):
+//
+//	curl -X POST http://localhost:8080/events \
+//	  -H "Content-Type: application/json" \
+//	  -H "Ce-Specversion: 1.0" \
+//	  -H "Ce-Type: create.order.command" \
+//	  -H "Ce-Source: /test" \
+//	  -H "Ce-Id: 1" \
+//	  -d '{"order_id":"ORD-1","amount":49.99}'
+//
+// Invalid (missing required field — returns 400):
+//
+//	curl -X POST http://localhost:8080/events \
+//	  -H "Content-Type: application/json" \
+//	  -H "Ce-Specversion: 1.0" \
+//	  -H "Ce-Type: create.order.command" \
+//	  -H "Ce-Source: /test" \
+//	  -H "Ce-Id: 2" \
+//	  -d '{"order_id":"ORD-2"}'
+//
+// View schema catalog:
+//
+//	curl http://localhost:8080/schemas
+//
+// View individual schema:
+//
+//	curl http://localhost:8080/schemas/create.order.command
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/fxsml/gopipe/message"
+	cehttp "github.com/fxsml/gopipe/message/http"
+	"github.com/fxsml/gopipe/message/jsonschema"
+	"github.com/fxsml/gopipe/pipe"
+)
+
+// Command schema — inbound data contract.
+const createOrderCommandSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"order_id": { "type": "string", "minLength": 1 },
+		"amount":   { "type": "number", "exclusiveMinimum": 0 }
+	},
+	"required": ["order_id", "amount"],
+	"additionalProperties": false
+}`
+
+// Event schema — outbound data contract.
+const orderCreatedEventSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"order_id": { "type": "string" },
+		"status":   { "type": "string" }
+	},
+	"required": ["order_id", "status"],
+	"additionalProperties": false
+}`
+
+// CreateOrderCommand is the inbound command payload.
+type CreateOrderCommand struct {
+	OrderID string  `json:"order_id"`
+	Amount  float64 `json:"amount"`
+}
+
+// OrderCreatedEvent is the outbound event payload.
+type OrderCreatedEvent struct {
+	OrderID string `json:"order_id"`
+	Status  string `json:"status"`
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// 1. Setup JSON Schema registry with validation for both types.
+	registry := jsonschema.NewRegistry(jsonschema.Config{
+		Naming: message.KebabNaming,
+	})
+	registry.MustRegisterType(CreateOrderCommand{}, createOrderCommandSchema)
+	registry.MustRegisterType(OrderCreatedEvent{}, orderCreatedEventSchema)
+
+	// 2. Setup HTTP CloudEvents subscriber.
+	subscriber := cehttp.NewSubscriber(cehttp.SubscriberConfig{})
+	rawInput, _ := subscriber.Subscribe(ctx)
+
+	// 3. Unmarshal pipe: RawMessage → Message (with validation middleware).
+	marshaler := message.NewJSONMarshaler()
+	unmarshalPipe := message.NewUnmarshalPipe(registry, marshaler, message.PipeConfig{})
+	unmarshalPipe.Use(jsonschema.NewInputValidationMiddleware(registry))
+	typed, _ := unmarshalPipe.Pipe(ctx, rawInput)
+
+	// 4. Router: handle messages and produce new messages.
+	router := message.NewRouter(message.PipeConfig{})
+	router.AddHandler("process-order", nil, message.NewCommandHandler(
+		func(ctx context.Context, cmd CreateOrderCommand) ([]OrderCreatedEvent, error) {
+			log.Printf("Processing order: %s ($%.2f)", cmd.OrderID, cmd.Amount)
+			return []OrderCreatedEvent{{
+				OrderID: cmd.OrderID,
+				Status:  "created",
+			}}, nil
+		},
+		message.CommandHandlerConfig{Source: "/orders", Naming: message.KebabNaming},
+	))
+	processed, _ := router.Pipe(ctx, typed)
+
+	// 5. Marshal pipe: Message → RawMessage (with validation middleware).
+	marshalPipe := message.NewMarshalPipe(marshaler, message.PipeConfig{})
+	marshalPipe.Use(jsonschema.NewOutputValidationMiddleware(registry))
+	rawOutput, _ := marshalPipe.Pipe(ctx, processed)
+
+	// 6. Sink to stdout using pipe primitive.
+	printer := pipe.NewSinkPipe(func(ctx context.Context, raw *message.RawMessage) error {
+		var data any
+		json.Unmarshal(raw.Data, &data)
+		formatted, _ := json.MarshalIndent(data, "", "  ")
+		fmt.Printf("\n[%s]\n%s\n", raw.Type(), formatted)
+		return nil
+	}, pipe.Config{})
+	done, _ := printer.Pipe(ctx, rawOutput)
+
+	// 7. HTTP routes: CloudEvents endpoint + schema discovery.
+	mux := http.NewServeMux()
+	mux.Handle("POST /events", subscriber)
+	mux.HandleFunc("GET /schemas", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/schema+json")
+		w.Write(registry.Schemas())
+	})
+	mux.HandleFunc("GET /schemas/{type}", func(w http.ResponseWriter, r *http.Request) {
+		eventType := r.PathValue("type")
+		schema := registry.Schema(eventType)
+
+		if schema == nil {
+			http.Error(w, "schema not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/schema+json")
+		w.Write(schema)
+	})
+
+	server := &http.Server{Addr: ":8080", Handler: mux}
+	go func() {
+		<-ctx.Done()
+		server.Shutdown(context.Background())
+	}()
+
+	fmt.Println("Listening on :8080")
+	fmt.Println("  POST /events         — CloudEvents endpoint")
+	fmt.Println("  GET  /schemas         — JSON Schema catalog")
+	fmt.Println("  GET  /schemas/{type}  — Individual schema")
+	fmt.Println()
+	fmt.Println("Pipeline: HTTP → Unmarshal → Router → Marshal → stdout")
+	fmt.Println()
+	fmt.Println("Try: curl -X POST http://localhost:8080/events \\")
+	fmt.Println(`       -H "Ce-Specversion: 1.0" -H "Ce-Id: 1" \`)
+	fmt.Println(`       -H "Ce-Type: create.order.command" -H "Ce-Source: /test" \`)
+	fmt.Println(`       -d '{"order_id":"ORD-1","amount":49.99}'`)
+	fmt.Println()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+
+	<-done
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,6 @@ module github.com/fxsml/gopipe/examples
 go 1.24.1
 
 require (
-	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/fxsml/gopipe/channel v0.16.0
 	github.com/fxsml/gopipe/message v0.11.0
 	github.com/fxsml/gopipe/pipe v0.16.0
@@ -11,11 +10,14 @@ require (
 )
 
 require (
+	github.com/cloudevents/sdk-go/v2 v2.16.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace (

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -3,6 +3,8 @@ github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -17,6 +19,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
@@ -29,6 +33,8 @@ go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/message/go.mod
+++ b/message/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fxsml/gopipe/channel v0.16.0
 	github.com/fxsml/gopipe/pipe v0.16.0
 	github.com/google/uuid v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )
 
 require (
@@ -15,6 +16,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace github.com/fxsml/gopipe/pipe => ../pipe

--- a/message/go.sum
+++ b/message/go.sum
@@ -3,6 +3,8 @@ github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fxsml/gopipe/channel v0.16.0 h1:ngHWVXOkPHxVjK1tIkaytoWZJhR2LIN2rXVwbv8scvk=
 github.com/fxsml/gopipe/channel v0.16.0/go.mod h1:KU0JFSXWGZnenOeWKWNU5CCfnfMWiKwtmjXh5bOS6r4=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -19,6 +21,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
@@ -31,6 +35,8 @@ go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/message/jsonschema/middleware.go
+++ b/message/jsonschema/middleware.go
@@ -1,0 +1,90 @@
+package jsonschema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fxsml/gopipe/message"
+	"github.com/fxsml/gopipe/pipe/middleware"
+)
+
+// NewValidationMiddleware creates middleware for validating RawMessage payloads.
+// Use this for proxy scenarios where messages pass through without unmarshaling.
+//
+// Example - HTTP → AMQP proxy with validation:
+//
+//	registry := jsonschema.NewRegistry(jsonschema.Config{})
+//	registry.MustRegister("order.created", orderSchema)
+//
+//	pipe := pipe.NewPassthroughPipe(cfg)
+//	pipe.Use(jsonschema.NewValidationMiddleware(registry))
+func NewValidationMiddleware(registry *Registry) middleware.Middleware[*message.RawMessage, *message.RawMessage] {
+	return func(next middleware.ProcessFunc[*message.RawMessage, *message.RawMessage]) middleware.ProcessFunc[*message.RawMessage, *message.RawMessage] {
+		return func(ctx context.Context, raw *message.RawMessage) ([]*message.RawMessage, error) {
+			// Validate before passing through
+			if err := registry.Validate(raw.Type(), raw.Data); err != nil {
+				return nil, fmt.Errorf("validation failed: %w", err)
+			}
+			return next(ctx, raw)
+		}
+	}
+}
+
+// NewInputValidationMiddleware creates middleware for validating before unmarshaling.
+// Use this with UnmarshalPipe to validate raw bytes before deserialization.
+//
+// Example - Validate before unmarshaling:
+//
+//	registry := jsonschema.NewRegistry(jsonschema.Config{
+//	    Naming: message.KebabNaming,
+//	})
+//	registry.MustRegisterType(CreateOrder{}, schema)
+//
+//	marshaler := message.NewJSONMarshaler()
+//	unmarshalPipe := message.NewUnmarshalPipe(registry, marshaler, cfg)
+//	unmarshalPipe.Use(jsonschema.NewInputValidationMiddleware(registry))
+func NewInputValidationMiddleware(registry *Registry) middleware.Middleware[*message.RawMessage, *message.Message] {
+	return func(next middleware.ProcessFunc[*message.RawMessage, *message.Message]) middleware.ProcessFunc[*message.RawMessage, *message.Message] {
+		return func(ctx context.Context, raw *message.RawMessage) ([]*message.Message, error) {
+			// Validate BEFORE unmarshaling (fail fast)
+			if err := registry.Validate(raw.Type(), raw.Data); err != nil {
+				return nil, fmt.Errorf("input validation failed: %w", err)
+			}
+			return next(ctx, raw)
+		}
+	}
+}
+
+// NewOutputValidationMiddleware creates middleware for validating after marshaling.
+// Use this with MarshalPipe to validate marshaled bytes before sending.
+//
+// Example - Validate after marshaling:
+//
+//	registry := jsonschema.NewRegistry(jsonschema.Config{
+//	    Naming: message.KebabNaming,
+//	})
+//	registry.MustRegisterType(OrderCreated{}, schema)
+//
+//	marshaler := message.NewJSONMarshaler()
+//	marshalPipe := message.NewMarshalPipe(marshaler, cfg)
+//	marshalPipe.Use(jsonschema.NewOutputValidationMiddleware(registry))
+func NewOutputValidationMiddleware(registry *Registry) middleware.Middleware[*message.Message, *message.RawMessage] {
+	return func(next middleware.ProcessFunc[*message.Message, *message.RawMessage]) middleware.ProcessFunc[*message.Message, *message.RawMessage] {
+		return func(ctx context.Context, msg *message.Message) ([]*message.RawMessage, error) {
+			// Marshal first
+			results, err := next(ctx, msg)
+			if err != nil {
+				return nil, err
+			}
+
+			// Validate AFTER marshaling
+			for _, raw := range results {
+				if err := registry.Validate(raw.Type(), raw.Data); err != nil {
+					return nil, fmt.Errorf("output validation failed: %w", err)
+				}
+			}
+
+			return results, nil
+		}
+	}
+}

--- a/message/jsonschema/registry.go
+++ b/message/jsonschema/registry.go
@@ -1,0 +1,235 @@
+// Package jsonschema provides schema validation for CloudEvents messages.
+//
+// Registry validates message payloads against JSON Schema definitions.
+// Schemas are the source of truth for data contracts. This solves the Go
+// zero-value dilemma: validation catches missing required fields before
+// encoding/json.Unmarshal fills them with zero values.
+//
+// Register schemas by CloudEvents type:
+//
+//	registry := jsonschema.NewRegistry(jsonschema.Config{
+//	    Naming: message.KebabNaming,
+//	})
+//	registry.MustRegisterType(CreateOrderCommand{}, commandSchema)
+//	// → registers as "create.order.command" with KebabNaming
+//
+// Validation middleware:
+//
+//	validator := jsonschema.NewValidationMiddleware(registry)
+//	pipe.Use(validator)
+//
+// Schema serving:
+//
+//	w.Header().Set("Content-Type", "application/schema+json")
+//	w.Write(registry.Schemas())  // All schemas as catalog
+//	w.Write(registry.Schema("order.created"))  // Individual schema
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	jschema "github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/fxsml/gopipe/message"
+)
+
+// Config configures the schema registry.
+type Config struct {
+	// Naming strategy for deriving CloudEvents types from Go types.
+	// Used by RegisterType to automatically convert Go type names to event types.
+	// Default: message.KebabNaming (CreateOrderCommand → "create.order.command")
+	Naming message.EventTypeNaming
+
+	// SchemaURI generates a unique URI for schema compilation.
+	// Optional. Defaults to urn:gopipe:schema:cloudevents:{eventType}
+	//
+	// The URI is used internally by the JSON Schema compiler and doesn't
+	// need to be resolvable. However, using HTTP URLs allows schemas to
+	// be published at those locations for external tooling.
+	//
+	// Example custom URIs:
+	//   - https://api.example.com/schemas/{eventType}
+	//   - urn:mycompany:events:{eventType}:schema
+	SchemaURI func(eventType string) string
+}
+
+// Registry validates message payloads against JSON Schema definitions.
+// It stores schemas by CloudEvents type and optionally tracks Go types
+// for convenience registration and InputRegistry implementation.
+//
+// Registry is thread-safe and can be shared across middleware and pipes.
+type Registry struct {
+	mu        sync.RWMutex
+	compiler  *jschema.Compiler
+	schemas   map[string]*entry          // eventType → schema
+	types     map[string]reflect.Type    // eventType → Go type (for InputRegistry)
+	reverse   map[reflect.Type]string    // Go type → eventType (for RegisterType)
+	naming    message.EventTypeNaming
+	schemaURI func(string) string        // eventType → URI for compiler
+}
+
+type entry struct {
+	compiled *jschema.Schema
+	raw      json.RawMessage
+}
+
+// NewRegistry creates a schema validation registry.
+// If cfg.Naming is nil, uses KebabNaming by default.
+// If cfg.SchemaURI is nil, uses defaultSchemaURI.
+func NewRegistry(cfg Config) *Registry {
+	if cfg.Naming == nil {
+		cfg.Naming = message.KebabNaming
+	}
+	if cfg.SchemaURI == nil {
+		cfg.SchemaURI = defaultSchemaURI
+	}
+	return &Registry{
+		compiler:  jschema.NewCompiler(),
+		schemas:   make(map[string]*entry),
+		types:     make(map[string]reflect.Type),
+		reverse:   make(map[reflect.Type]string),
+		naming:    cfg.Naming,
+		schemaURI: cfg.SchemaURI,
+	}
+}
+
+// RegisterType associates a JSON Schema with a Go type.
+// The CloudEvents type is derived using the naming strategy.
+//
+// Example:
+//
+//	registry.RegisterType(CreateOrderCommand{}, commandSchema)
+//	// With KebabNaming: CreateOrderCommand → "create.order.command"
+//
+// The Go type is tracked for InputRegistry.NewInput() support.
+func (r *Registry) RegisterType(v any, schemaJSON string) error {
+	t := elemType(v)
+	eventType := r.naming.EventType(t)
+	uri := r.schemaURI(eventType)
+
+	// Compile schema
+	doc, err := jschema.UnmarshalJSON(strings.NewReader(schemaJSON))
+	if err != nil {
+		return fmt.Errorf("jsonschema: parsing schema for %s: %w", eventType, err)
+	}
+	if err := r.compiler.AddResource(uri, doc); err != nil {
+		return fmt.Errorf("jsonschema: adding resource for %s: %w", eventType, err)
+	}
+	compiled, err := r.compiler.Compile(uri)
+	if err != nil {
+		return fmt.Errorf("jsonschema: compiling schema for %s: %w", eventType, err)
+	}
+
+	// Store schema and track Go type
+	r.mu.Lock()
+	r.schemas[eventType] = &entry{compiled: compiled, raw: json.RawMessage(schemaJSON)}
+	r.types[eventType] = t
+	r.reverse[t] = eventType
+	r.mu.Unlock()
+
+	return nil
+}
+
+// MustRegisterType is like RegisterType but panics on error.
+func (r *Registry) MustRegisterType(v any, schemaJSON string) {
+	if err := r.RegisterType(v, schemaJSON); err != nil {
+		panic(err)
+	}
+}
+
+// Validate validates data against the schema for the given CloudEvents type.
+// Returns an error if no schema is registered for the type.
+// Returns validation error if data doesn't conform to the schema.
+func (r *Registry) Validate(eventType string, data []byte) error {
+	r.mu.RLock()
+	e, ok := r.schemas[eventType]
+	r.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("jsonschema: no schema registered for type %q", eventType)
+	}
+
+	inst, err := jschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	return e.compiled.Validate(inst)
+}
+
+// Schema returns the raw JSON Schema for a CloudEvents type.
+// Returns nil if no schema is registered for the type.
+//
+// Use this for serving individual schemas:
+//
+//	schema := registry.Schema("order.created")
+//	w.Header().Set("Content-Type", "application/schema+json")
+//	w.Write(schema)
+func (r *Registry) Schema(eventType string) json.RawMessage {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if e, ok := r.schemas[eventType]; ok {
+		return e.raw
+	}
+	return nil
+}
+
+// Schemas returns a composed JSON Schema document containing all registered
+// schemas under $defs, keyed by CloudEvents type. The document is a valid
+// JSON Schema that can be served as an API contract catalog.
+//
+// Use this for serving schema catalogs:
+//
+//	w.Header().Set("Content-Type", "application/schema+json")
+//	w.Write(registry.Schemas())
+func (r *Registry) Schemas() json.RawMessage {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	defs := make(map[string]json.RawMessage, len(r.schemas))
+	for eventType, e := range r.schemas {
+		defs[eventType] = e.raw
+	}
+
+	doc := struct {
+		Schema string                     `json:"$schema"`
+		Defs   map[string]json.RawMessage `json:"$defs"`
+	}{
+		Schema: "https://json-schema.org/draft/2020-12/schema",
+		Defs:   defs,
+	}
+	data, _ := json.Marshal(doc)
+	return data
+}
+
+// NewInput creates a typed instance for the given CloudEvents type.
+// Implements message.InputRegistry.
+//
+// Returns nil if no Go type was registered for the CloudEvents type.
+func (r *Registry) NewInput(eventType string) any {
+	r.mu.RLock()
+	t, ok := r.types[eventType]
+	r.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return reflect.New(t).Interface()
+}
+
+// Verify Registry implements InputRegistry.
+var _ message.InputRegistry = (*Registry)(nil)
+
+func elemType(v any) reflect.Type {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+func defaultSchemaURI(eventType string) string {
+	return fmt.Sprintf("urn:gopipe:schema:cloudevents:%s", eventType)
+}

--- a/message/jsonschema/registry_test.go
+++ b/message/jsonschema/registry_test.go
@@ -1,0 +1,463 @@
+package jsonschema
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jschema "github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/fxsml/gopipe/message"
+)
+
+const testSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"name":  { "type": "string", "minLength": 1 },
+		"value": { "type": "number" }
+	},
+	"required": ["name", "value"],
+	"additionalProperties": false
+}`
+
+type testData struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+const testOtherSchema = `{
+	"type": "object",
+	"properties": {
+		"id": { "type": "string" }
+	},
+	"required": ["id"]
+}`
+
+type testOther struct {
+	ID string `json:"id"`
+}
+
+func TestRegistry_RegisterType(t *testing.T) {
+	t.Run("registers type with KebabNaming", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		if err := registry.RegisterType(testData{}, testSchema); err != nil {
+			t.Fatalf("RegisterType failed: %v", err)
+		}
+
+		// Should be accessible by derived eventType
+		schema := registry.Schema("test.data")
+		if schema == nil {
+			t.Fatal("expected schema for test.data")
+		}
+	})
+
+	t.Run("registers type with SnakeNaming", func(t *testing.T) {
+		registry := NewRegistry(Config{Naming: message.SnakeNaming})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		schema := registry.Schema("test_data")
+		if schema == nil {
+			t.Fatal("expected schema for test_data")
+		}
+	})
+
+	t.Run("invalid schema JSON", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		err := registry.RegisterType(testData{}, `{not valid json}`)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("custom SchemaURI function", func(t *testing.T) {
+		customURICalled := false
+		registry := NewRegistry(Config{
+			SchemaURI: func(eventType string) string {
+				customURICalled = true
+				return "https://example.com/schemas/" + eventType
+			},
+		})
+
+		err := registry.RegisterType(testData{}, testSchema)
+		if err != nil {
+			t.Fatalf("RegisterType failed: %v", err)
+		}
+
+		if !customURICalled {
+			t.Error("custom SchemaURI function was not called")
+		}
+
+		// Verify schema is registered and validates correctly
+		if err := registry.Validate("test.data", []byte(`{"name":"ok","value":1}`)); err != nil {
+			t.Errorf("validation failed with custom URI: %v", err)
+		}
+	})
+}
+
+func TestRegistry_Validate(t *testing.T) {
+	t.Run("valid data", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		err := registry.Validate("test.data", []byte(`{"name":"ok","value":42}`))
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("missing required field", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		err := registry.Validate("test.data", []byte(`{"name":"ok"}`))
+		if err == nil {
+			t.Fatal("expected validation error for missing required field")
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		err := registry.Validate("test.data", []byte(`{"name":"ok","value":"not-a-number"}`))
+		if err == nil {
+			t.Fatal("expected validation error for wrong type")
+		}
+	})
+
+	t.Run("empty required string", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		err := registry.Validate("test.data", []byte(`{"name":"","value":1}`))
+		if err == nil {
+			t.Fatal("expected validation error for empty string with minLength: 1")
+		}
+	})
+
+	t.Run("additional properties rejected", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		err := registry.Validate("test.data", []byte(`{"name":"ok","value":1,"extra":"field"}`))
+		if err == nil {
+			t.Fatal("expected validation error for additional properties")
+		}
+	})
+
+	t.Run("no schema registered returns error", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+
+		err := registry.Validate("unknown.type", []byte(`{"any":"data"}`))
+		if err == nil {
+			t.Fatal("expected error for unregistered type")
+		}
+		if !strings.Contains(err.Error(), "no schema registered") {
+			t.Errorf("expected 'no schema registered' error, got: %v", err)
+		}
+	})
+}
+
+func TestRegistry_Schema(t *testing.T) {
+	t.Run("returns schema by eventType", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		schema := registry.Schema("test.data")
+		if schema == nil {
+			t.Fatal("expected non-nil schema")
+		}
+		if !json.Valid(schema) {
+			t.Error("schema is not valid JSON")
+		}
+	})
+
+	t.Run("returns nil for unregistered type", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		schema := registry.Schema("unknown.type")
+		if schema != nil {
+			t.Errorf("expected nil, got %s", schema)
+		}
+	})
+}
+
+func TestRegistry_Schemas(t *testing.T) {
+	t.Run("composes all registered types", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+		registry.MustRegisterType(testOther{}, testOtherSchema)
+
+		raw := registry.Schemas()
+		if raw == nil {
+			t.Fatal("expected non-nil schemas")
+		}
+		if !json.Valid(raw) {
+			t.Fatal("schemas document is not valid JSON")
+		}
+
+		var doc struct {
+			Schema string                     `json:"$schema"`
+			Defs   map[string]json.RawMessage `json:"$defs"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if doc.Schema != "https://json-schema.org/draft/2020-12/schema" {
+			t.Errorf("$schema = %q", doc.Schema)
+		}
+		if len(doc.Defs) != 2 {
+			t.Fatalf("$defs count = %d, want 2", len(doc.Defs))
+		}
+		if _, ok := doc.Defs["test.data"]; !ok {
+			t.Error("missing $defs/test.data")
+		}
+		if _, ok := doc.Defs["test.other"]; !ok {
+			t.Error("missing $defs/test.other")
+		}
+	})
+
+	t.Run("composed document is valid JSON Schema", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+		registry.MustRegisterType(testOther{}, testOtherSchema)
+
+		raw := registry.Schemas()
+
+		compiler := jschema.NewCompiler()
+		doc, err := jschema.UnmarshalJSON(strings.NewReader(string(raw)))
+		if err != nil {
+			t.Fatalf("unmarshal as JSON Schema: %v", err)
+		}
+		if err := compiler.AddResource("urn:test:catalog", doc); err != nil {
+			t.Fatalf("add resource: %v", err)
+		}
+		if _, err := compiler.Compile("urn:test:catalog"); err != nil {
+			t.Fatalf("composed schema does not compile as valid JSON Schema: %v", err)
+		}
+	})
+
+	t.Run("empty defs when no schemas", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		raw := registry.Schemas()
+
+		var doc struct {
+			Defs map[string]json.RawMessage `json:"$defs"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(doc.Defs) != 0 {
+			t.Errorf("expected empty $defs, got %d", len(doc.Defs))
+		}
+	})
+}
+
+func TestRegistry_NewInput(t *testing.T) {
+	t.Run("creates instance for registered type", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+
+		instance := registry.NewInput("test.data")
+		if instance == nil {
+			t.Fatal("expected instance, got nil")
+		}
+
+		ptr, ok := instance.(*testData)
+		if !ok {
+			t.Fatalf("expected *testData, got %T", instance)
+		}
+
+		if ptr.Name != "" || ptr.Value != 0 {
+			t.Errorf("expected zero values, got Name=%q Value=%d", ptr.Name, ptr.Value)
+		}
+	})
+
+	t.Run("returns nil for unregistered type", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		instance := registry.NewInput("unknown.type")
+		if instance != nil {
+			t.Errorf("expected nil, got %v", instance)
+		}
+	})
+
+	t.Run("handles multiple registered types", func(t *testing.T) {
+		registry := NewRegistry(Config{})
+		registry.MustRegisterType(testData{}, testSchema)
+		registry.MustRegisterType(testOther{}, testOtherSchema)
+
+		data := registry.NewInput("test.data")
+		if data == nil {
+			t.Error("expected testData instance")
+		}
+
+		other := registry.NewInput("test.other")
+		if other == nil {
+			t.Error("expected testOther instance")
+		}
+
+		unknown := registry.NewInput("test.unknown")
+		if unknown != nil {
+			t.Error("expected nil for unknown type")
+		}
+	})
+}
+
+func TestRegistry_MustRegisterType_panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for invalid schema")
+		}
+	}()
+	registry := NewRegistry(Config{})
+	registry.MustRegisterType(testData{}, `{not valid}`)
+}
+
+func TestRegistry_RegisterType_pointer(t *testing.T) {
+	registry := NewRegistry(Config{})
+	if err := registry.RegisterType(&testData{}, testSchema); err != nil {
+		t.Fatalf("RegisterType with pointer failed: %v", err)
+	}
+	if schema := registry.Schema("test.data"); schema == nil {
+		t.Fatal("expected schema for test.data via pointer registration")
+	}
+}
+
+func TestRegistry_Validate_invalid_json(t *testing.T) {
+	registry := NewRegistry(Config{})
+	registry.MustRegisterType(testData{}, testSchema)
+
+	err := registry.Validate("test.data", []byte(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestNewValidationMiddleware(t *testing.T) {
+	registry := NewRegistry(Config{})
+	registry.MustRegisterType(testData{}, testSchema)
+	mw := NewValidationMiddleware(registry)
+
+	passthrough := func(_ context.Context, raw *message.RawMessage) ([]*message.RawMessage, error) {
+		return []*message.RawMessage{raw}, nil
+	}
+	fn := mw(passthrough)
+
+	t.Run("valid message passes through", func(t *testing.T) {
+		raw := message.NewRaw([]byte(`{"name":"ok","value":1}`), message.Attributes{"type": "test.data"}, nil)
+		results, err := fn(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("invalid message rejected", func(t *testing.T) {
+		raw := message.NewRaw([]byte(`{"name":"ok"}`), message.Attributes{"type": "test.data"}, nil)
+		_, err := fn(context.Background(), raw)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "validation failed") {
+			t.Errorf("expected 'validation failed' prefix, got: %v", err)
+		}
+	})
+
+	t.Run("unregistered type returns error", func(t *testing.T) {
+		raw := message.NewRaw([]byte(`{"any":"data"}`), message.Attributes{"type": "unknown"}, nil)
+		_, err := fn(context.Background(), raw)
+		if err == nil {
+			t.Fatal("expected error for unregistered type")
+		}
+	})
+}
+
+func TestNewInputValidationMiddleware(t *testing.T) {
+	registry := NewRegistry(Config{})
+	registry.MustRegisterType(testData{}, testSchema)
+	mw := NewInputValidationMiddleware(registry)
+
+	next := func(_ context.Context, raw *message.RawMessage) ([]*message.Message, error) {
+		return []*message.Message{message.New(nil, raw.Attributes, nil)}, nil
+	}
+	fn := mw(next)
+
+	t.Run("valid message passes to next", func(t *testing.T) {
+		raw := message.NewRaw([]byte(`{"name":"ok","value":1}`), message.Attributes{"type": "test.data"}, nil)
+		results, err := fn(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("invalid message rejected before next", func(t *testing.T) {
+		raw := message.NewRaw([]byte(`{"name":"ok"}`), message.Attributes{"type": "test.data"}, nil)
+		_, err := fn(context.Background(), raw)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "input validation failed") {
+			t.Errorf("expected 'input validation failed' prefix, got: %v", err)
+		}
+	})
+}
+
+func TestNewOutputValidationMiddleware(t *testing.T) {
+	registry := NewRegistry(Config{})
+	registry.MustRegisterType(testData{}, testSchema)
+	mw := NewOutputValidationMiddleware(registry)
+
+	t.Run("valid output passes", func(t *testing.T) {
+		next := func(_ context.Context, msg *message.Message) ([]*message.RawMessage, error) {
+			return []*message.RawMessage{
+				message.NewRaw([]byte(`{"name":"ok","value":1}`), message.Attributes{"type": "test.data"}, nil),
+			}, nil
+		}
+		fn := mw(next)
+
+		msg := message.New(testData{Name: "ok", Value: 1}, message.Attributes{"type": "test.data"}, nil)
+		results, err := fn(context.Background(), msg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("invalid output rejected", func(t *testing.T) {
+		next := func(_ context.Context, msg *message.Message) ([]*message.RawMessage, error) {
+			return []*message.RawMessage{
+				message.NewRaw([]byte(`{"name":"ok"}`), message.Attributes{"type": "test.data"}, nil),
+			}, nil
+		}
+		fn := mw(next)
+
+		msg := message.New(nil, message.Attributes{"type": "test.data"}, nil)
+		_, err := fn(context.Background(), msg)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+		if !strings.Contains(err.Error(), "output validation failed") {
+			t.Errorf("expected 'output validation failed' prefix, got: %v", err)
+		}
+	})
+
+	t.Run("next error propagated", func(t *testing.T) {
+		next := func(_ context.Context, msg *message.Message) ([]*message.RawMessage, error) {
+			return nil, context.Canceled
+		}
+		fn := mw(next)
+
+		msg := message.New(nil, message.Attributes{"type": "test.data"}, nil)
+		_, err := fn(context.Background(), msg)
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a new `message/jsonschema` subpackage for JSON Schema validation of CloudEvents message payloads.

- **Registry** manages schemas by CloudEvents type (Draft 2020-12 via `santhosh-tekuri/jsonschema/v6`)
  - `RegisterType(v, schema)` derives eventType from Go types via naming strategy
  - `Validate(eventType, data)` validates raw bytes against compiled schemas; errors on unregistered types
  - `Schema(eventType)` / `Schemas()` for HTTP schema serving
  - Implements `InputRegistry` for UnmarshalPipe integration
  - Thread-safe, configurable `SchemaURI` and `Naming`

- **Three validation middleware** for different pipe stages
  - `NewInputValidationMiddleware` — validates before unmarshaling (fail fast)
  - `NewOutputValidationMiddleware` — validates after marshaling
  - `NewValidationMiddleware` — proxy scenarios (RawMessage → RawMessage)

- **Example** `examples/07-validating-marshaler` — HTTP CloudEvents service with command/event separation, schema serving (`GET /schemas`, `GET /schemas/{type}`), and manual pipe composition

- **Docs** — ADR 0027, plan, design decisions, CHANGELOG entry

## Test plan

- [x] Registry: RegisterType, Validate, Schema, Schemas, NewInput
- [x] Strict validation: unregistered types return error
- [x] All three middleware: valid/invalid/error propagation
- [x] Composed schema catalog compiles as valid JSON Schema
- [x] 97.4% statement coverage

## Related

- ADR 0027 — JSON Schema Validation
- Related: ADR 0022 (Message Package Redesign), ADR 0024 (HTTP CloudEvents Adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)