### PR TITLE
Add Validator hook and refactor Enricher to receive message batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **message/http:** `SubscriberConfig.Validator` callback for validating parsed messages before delivery
+  - Called after message creation, before Enricher and channel delivery
+  - Receives the full `[]*message.RawMessage` slice and `*http.Request`
+  - On error, all messages are nacked and an HTTP error is returned
+  - Errors implementing `StatusCoder` interface control the HTTP status code; otherwise defaults to 400
 - **message/http:** `SubscriberConfig.Enricher` callback for bridging HTTP request data into message locals
-  - Called after message creation, before channel delivery
+  - Called after Validator, before channel delivery
+  - Receives the full `[]*message.RawMessage` slice and `*http.Request`
   - Enables auth claims propagation from HTTP middleware (e.g., sidecar) into messages via `SetLocal`
-  - For batch requests, called per message with the same `*http.Request`
   - Optional — nil enricher is a no-op
 - **message:** `SetLocal(key, val)` / `Local(key)` for in-process context propagation
   - Message-local values via `map[any]any`, never serialized, never crosses broker boundaries

--- a/docs/plans/oauth2-cloudevents.decisions.md
+++ b/docs/plans/oauth2-cloudevents.decisions.md
@@ -84,7 +84,7 @@ Clear, explicit, no new types to learn. The user controls the claims type. **Cut
 
 ### `MessageEnricher` Named Type
 
-`func(*http.Request, *message.RawMessage)` inline in the config is sufficient. Not an interface, not reused elsewhere. **Cut** the named type — keep it as an anonymous function type on the config field.
+`func(*http.Request, []*message.RawMessage)` inline in the config is sufficient. Not an interface, not reused elsewhere. **Cut** the named type — keep it as an anonymous function type on the config field. The slice-based signature makes both `Enricher` and `Validator` transparent about HTTP request cardinality.
 
 ### Publisher `TokenSource`
 
@@ -124,7 +124,8 @@ The enricher is opt-in, explicit about what crosses the HTTP→message boundary,
 type SubscriberConfig struct {
     BufferSize int
     AckTimeout time.Duration
-    Enricher   func(*http.Request, *message.RawMessage) // optional
+    Validator  func(*http.Request, []*message.RawMessage) error // optional
+    Enricher   func(*http.Request, []*message.RawMessage)       // optional
 }
 ```
 
@@ -133,6 +134,7 @@ type SubscriberConfig struct {
 | Component | API |
 |-----------|-----|
 | Authentication | None — external HTTP middleware or sidecar |
+| Validation | `SubscriberConfig.Validator` — one config field |
 | Propagation | `SubscriberConfig.Enricher` — one config field |
 | Authorization | None — user writes a `message.Middleware` |
 

--- a/docs/plans/oauth2-cloudevents.md
+++ b/docs/plans/oauth2-cloudevents.md
@@ -70,15 +70,19 @@ One new config field. The enricher runs after message creation, before channel d
 type SubscriberConfig struct {
     BufferSize int
     AckTimeout time.Duration
-    Enricher   func(*http.Request, *message.RawMessage) // optional
+    Validator  func(*http.Request, []*message.RawMessage) error // optional
+    Enricher   func(*http.Request, []*message.RawMessage)       // optional
 }
 ```
 
-In `ServeHTTP`, after `ce.FromCloudEvent`:
+In `ServeHTTP`, after creating all messages from `ce.FromCloudEvent`:
 
 ```go
+if s.cfg.Validator != nil {
+    if err := s.cfg.Validator(r, msgs); err != nil { /* nack all, return HTTP error */ }
+}
 if s.cfg.Enricher != nil {
-    s.cfg.Enricher(r, msg)
+    s.cfg.Enricher(r, msgs)
 }
 ```
 
@@ -86,11 +90,13 @@ Usage (sidecar scenario — claims in headers):
 
 ```go
 subscriber := http.NewSubscriber(http.SubscriberConfig{
-    Enricher: func(r *http.Request, msg *message.RawMessage) {
-        msg.SetLocal(principalKey, Principal{
-            Subject: r.Header.Get("X-Auth-Subject"),
-            Scopes:  strings.Split(r.Header.Get("X-Auth-Scopes"), ","),
-        })
+    Enricher: func(r *http.Request, msgs []*message.RawMessage) {
+        for _, msg := range msgs {
+            msg.SetLocal(principalKey, Principal{
+                Subject: r.Header.Get("X-Auth-Subject"),
+                Scopes:  strings.Split(r.Header.Get("X-Auth-Scopes"), ","),
+            })
+        }
     },
 })
 ```
@@ -99,9 +105,11 @@ Usage (application middleware scenario — claims in context):
 
 ```go
 subscriber := http.NewSubscriber(http.SubscriberConfig{
-    Enricher: func(r *http.Request, msg *message.RawMessage) {
+    Enricher: func(r *http.Request, msgs []*message.RawMessage) {
         claims, _ := authn.ClaimsFromContext(r.Context())
-        msg.SetLocal(principalKey, claims)
+        for _, msg := range msgs {
+            msg.SetLocal(principalKey, claims)
+        }
     },
 })
 ```
@@ -142,7 +150,7 @@ Client → Envoy (validates JWT, injects X-Auth-* headers) → Pod
            │
     Subscriber.ServeHTTP
            │
-    Enricher: msg.SetLocal(principalKey, Principal{...})
+    Enricher: for each msg → msg.SetLocal(principalKey, Principal{...})
            │
     UnmarshalPipe (preserves locals)
            │
@@ -193,10 +201,10 @@ return []*Message{{
 - `message/http/subscriber.go` — add `Enricher` field to config, call in `ServeHTTP`
 
 **Acceptance Criteria:**
-- [ ] Enricher called once per message after creation, before channel delivery
-- [ ] Enricher has access to `*http.Request` and `*message.RawMessage`
+- [ ] Enricher called with full message slice after Validator, before channel delivery
+- [ ] Enricher has access to `*http.Request` and `[]*message.RawMessage`
 - [ ] Nil enricher is no-op (existing behavior unchanged)
-- [ ] Batch mode: enricher called per message, same request
+- [ ] Validator called before Enricher; on error, all messages nacked
 
 ## Implementation Order
 

--- a/message/http/subscriber.go
+++ b/message/http/subscriber.go
@@ -13,6 +13,13 @@ import (
 	ce "github.com/fxsml/gopipe/message/cloudevents"
 )
 
+// StatusCoder is an optional interface for errors returned by Validator.
+// If the error implements StatusCoder, the HTTP response uses that status code;
+// otherwise it defaults to 400 Bad Request.
+type StatusCoder interface {
+	StatusCode() int
+}
+
 // SubscriberConfig configures an HTTP CloudEvents Subscriber.
 type SubscriberConfig struct {
 	// BufferSize is the channel buffer size (default: 100).
@@ -21,11 +28,16 @@ type SubscriberConfig struct {
 	// AckTimeout is the maximum time to wait for ack/nack (default: 30s).
 	AckTimeout time.Duration
 
-	// Enricher is called after message creation and before channel delivery.
+	// Validator is called after message creation and before Enricher.
+	// If it returns a non-nil error, all messages are nacked and the error
+	// is returned as the HTTP response. Errors implementing StatusCoder
+	// control the HTTP status; otherwise 400 is used.
+	Validator func(*http.Request, []*message.RawMessage) error
+
+	// Enricher is called after Validator and before channel delivery.
 	// Use it to bridge HTTP request data into message locals (e.g., auth claims).
-	// Called once per message. For batch requests, called per message with the
-	// same *http.Request.
-	Enricher func(*http.Request, *message.RawMessage)
+	// Receives the full message slice for the request.
+	Enricher func(*http.Request, []*message.RawMessage)
 }
 
 func (c SubscriberConfig) parse() SubscriberConfig {
@@ -158,17 +170,38 @@ func (s *Subscriber) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		len(events),
 	)
 
+	msgs := make([]*message.RawMessage, 0, len(events))
 	for i := range events {
 		msg, err := ce.FromCloudEvent(&events[i], shared)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		msgs = append(msgs, msg)
+	}
 
-		if s.cfg.Enricher != nil {
-			s.cfg.Enricher(r, msg)
+	// Validate: on error, nack all and return HTTP error.
+	if s.cfg.Validator != nil {
+		if err := s.cfg.Validator(r, msgs); err != nil {
+			for _, msg := range msgs {
+				msg.Nack(err)
+			}
+			code := http.StatusBadRequest
+			var sc StatusCoder
+			if errors.As(err, &sc) {
+				code = sc.StatusCode()
+			}
+			http.Error(w, err.Error(), code)
+			return
 		}
+	}
 
+	// Enrich before channel delivery.
+	if s.cfg.Enricher != nil {
+		s.cfg.Enricher(r, msgs)
+	}
+
+	for _, msg := range msgs {
 		select {
 		case s.ch <- msg:
 		case <-s.done:

--- a/message/http/subscriber_test.go
+++ b/message/http/subscriber_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -385,8 +386,10 @@ func TestSubscriber_Enricher(t *testing.T) {
 
 		sub := NewSubscriber(SubscriberConfig{
 			AckTimeout: time.Second,
-			Enricher: func(r *http.Request, msg *message.RawMessage) {
-				msg.SetLocal(keyType{}, r.Header.Get("X-Tenant-ID"))
+			Enricher: func(r *http.Request, msgs []*message.RawMessage) {
+				for _, msg := range msgs {
+					msg.SetLocal(keyType{}, r.Header.Get("X-Tenant-ID"))
+				}
 			},
 		})
 		ctx, cancel := context.WithCancel(context.Background())
@@ -416,15 +419,15 @@ func TestSubscriber_Enricher(t *testing.T) {
 		}
 	})
 
-	t.Run("enricher called per message in batch", func(t *testing.T) {
+	t.Run("enricher receives full batch slice", func(t *testing.T) {
 		type keyType struct{}
-		var count int
 
 		sub := NewSubscriber(SubscriberConfig{
 			AckTimeout: time.Second,
-			Enricher: func(r *http.Request, msg *message.RawMessage) {
-				count++
-				msg.SetLocal(keyType{}, count)
+			Enricher: func(r *http.Request, msgs []*message.RawMessage) {
+				for i, msg := range msgs {
+					msg.SetLocal(keyType{}, i+1)
+				}
 			},
 		})
 		ctx, cancel := context.WithCancel(context.Background())
@@ -451,9 +454,6 @@ func TestSubscriber_Enricher(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Fatalf("expected %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
 		}
-		if count != 2 {
-			t.Errorf("enricher called %d times, want 2", count)
-		}
 	})
 
 	t.Run("nil enricher is no-op", func(t *testing.T) {
@@ -476,6 +476,234 @@ func TestSubscriber_Enricher(t *testing.T) {
 
 		if w.Code != http.StatusOK {
 			t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+}
+
+// statusError is a test helper that implements StatusCoder.
+type statusError struct {
+	code int
+	msg  string
+}
+
+func (e *statusError) Error() string    { return e.msg }
+func (e *statusError) StatusCode() int  { return e.code }
+
+func TestSubscriber_Validator(t *testing.T) {
+	t.Run("nil validator is no-op", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{AckTimeout: time.Second})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ch, _ := sub.Subscribe(ctx)
+
+		go func() {
+			msg := <-ch
+			msg.Ack()
+		}()
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("validator error returns 400 by default", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				return errors.New("invalid payload")
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, _ = sub.Subscribe(ctx)
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+
+	t.Run("validator error with StatusCoder uses custom status", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				return &statusError{code: http.StatusForbidden, msg: "forbidden"}
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, _ = sub.Subscribe(ctx)
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected %d, got %d", http.StatusForbidden, w.Code)
+		}
+	})
+
+	t.Run("validator wrapped error with StatusCoder unwraps correctly", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				return fmt.Errorf("validation: %w", &statusError{code: http.StatusForbidden, msg: "forbidden"})
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, _ = sub.Subscribe(ctx)
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected %d, got %d", http.StatusForbidden, w.Code)
+		}
+	})
+
+	t.Run("validator error nacks all messages in batch", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				if len(msgs) != 2 {
+					t.Errorf("expected 2 messages, got %d", len(msgs))
+				}
+				return errors.New("batch rejected")
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, _ = sub.Subscribe(ctx)
+
+		body := []byte(`[
+			{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}},
+			{"specversion":"1.0","id":"2","type":"test","source":"/test","data":{}}
+		]`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsBatchJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+
+	t.Run("validator success allows delivery", func(t *testing.T) {
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				return nil // pass
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ch, _ := sub.Subscribe(ctx)
+
+		go func() {
+			msg := <-ch
+			msg.Ack()
+		}()
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("validator runs before enricher", func(t *testing.T) {
+		var order []string
+
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				order = append(order, "validator")
+				return nil
+			},
+			Enricher: func(r *http.Request, msgs []*message.RawMessage) {
+				order = append(order, "enricher")
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ch, _ := sub.Subscribe(ctx)
+
+		go func() {
+			msg := <-ch
+			msg.Ack()
+		}()
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected %d, got %d", http.StatusOK, w.Code)
+		}
+		if len(order) != 2 || order[0] != "validator" || order[1] != "enricher" {
+			t.Errorf("expected [validator enricher], got %v", order)
+		}
+	})
+
+	t.Run("validator error skips enricher", func(t *testing.T) {
+		enricherCalled := false
+
+		sub := NewSubscriber(SubscriberConfig{
+			AckTimeout: time.Second,
+			Validator: func(r *http.Request, msgs []*message.RawMessage) error {
+				return errors.New("rejected")
+			},
+			Enricher: func(r *http.Request, msgs []*message.RawMessage) {
+				enricherCalled = true
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, _ = sub.Subscribe(ctx)
+
+		body := []byte(`{"specversion":"1.0","id":"1","type":"test","source":"/test","data":{}}`)
+		req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+		req.Header.Set("Content-Type", ContentTypeCloudEventsJSON)
+		w := httptest.NewRecorder()
+
+		sub.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+		}
+		if enricherCalled {
+			t.Error("enricher should not be called when validator fails")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
This change introduces a new `Validator` hook to the HTTP Subscriber and refactors the `Enricher` hook to receive the full message batch instead of individual messages. The validator runs before enrichment and can reject entire batches with custom HTTP status codes.

## Key Changes
- **New `Validator` hook**: Added to `SubscriberConfig` to validate messages after parsing but before enrichment. Returns an error to reject the batch with an HTTP response.
- **`StatusCoder` interface**: New optional interface for validator errors to specify custom HTTP status codes (defaults to 400 Bad Request if not implemented).
- **Enricher signature change**: Changed from `func(*http.Request, *message.RawMessage)` to `func(*http.Request, []*message.RawMessage)` to receive the complete batch, eliminating per-message calls.
- **Execution order**: Validator runs first, then Enricher only if validation succeeds. If validation fails, all messages are nacked and enricher is skipped.
- **Batch handling**: Messages are now collected into a slice before validation/enrichment, enabling batch-level operations.

## Implementation Details
- When validator returns an error, all messages in the batch are nacked with that error before returning the HTTP response
- The validator receives the full request context and all parsed messages, enabling cross-message validation logic
- Enricher now iterates over the message slice internally, giving it full control over batch processing
- Updated test suite with comprehensive validator tests covering nil validator, error handling, status codes, batch rejection, and execution order

https://claude.ai/code/session_01Nt2xAaooF1BX1aw9Vm1jFK