### PR TITLE
feat: add Claude Code skills, hooks, and CLAUDE.md integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,44 @@
+# gopipe
+
+Go library for composable data pipelines with CloudEvents support.
+
+@../AGENTS.md
+
+## Procedures
+
+Load these on demand when the relevant task arises:
+
+| Task | Procedure |
+|------|-----------|
+| Git workflow, branch naming, commits | @../docs/procedures/git.md |
+| Go standards, godoc, testing | @../docs/procedures/go.md |
+| Documentation, CHANGELOG, doc linting | @../docs/procedures/documentation.md |
+| Planning and plan documents | @../docs/procedures/planning.md |
+| ADR creation and lifecycle | @../docs/procedures/adr.md |
+| Feature branch merge (history cleanup) | @../docs/procedures/feature-release.md |
+| Release and multi-module tagging | @../docs/procedures/release.md |
+
+## Claude Code Skills
+
+### Auto-Applied (context-loaded)
+
+| Skill | When Used |
+|-------|-----------|
+| `managing-git-workflow` | Any git, branch, or release operation |
+| `developing-go-code` | Writing or reviewing Go code |
+| `building-message-pipelines` | Working with the message package |
+
+### Slash Commands (user-invoked)
+
+| Command | Purpose |
+|---------|---------|
+| `/release-feature BRANCH` | Merge feature branch to develop (Phases 1–3) |
+| `/release VERSION` | Release develop to main with tags (Phases 4–6) |
+| `/hotfix NAME` | Create and release a hotfix |
+| `/create-feature NAME` | Create feature branch from develop |
+| `/verify` | Run `make test && make build && make vet` |
+| `/docs-lint` | Check documentation quality |
+| `/create-adr TITLE` | Create new Architecture Decision Record |
+| `/create-plan TITLE` | Create implementation plan |
+| `/changelog TYPE DESC` | Add entry to CHANGELOG |
+| `/review-pr [NUMBER]` | Review PR against project standards |

--- a/.claude/hooks/gofmt.sh
+++ b/.claude/hooks/gofmt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format .go files after Edit/Write
+
+TMPFILE=$(mktemp)
+trap "rm -f $TMPFILE" EXIT
+cat > "$TMPFILE"
+
+FILE=$(python3 -c "
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data.get('tool_input', {}).get('file_path', ''))
+" "$TMPFILE" 2>/dev/null || echo "")
+
+if [[ "$FILE" == *.go && -f "$FILE" ]]; then
+    gofmt -w "$FILE"
+fi
+
+exit 0

--- a/.claude/hooks/test-guard.sh
+++ b/.claude/hooks/test-guard.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PreToolUse hook: run make test/build/vet before git commit/push
+
+TMPFILE=$(mktemp)
+LOG=$(mktemp)
+trap "rm -f $TMPFILE $LOG" EXIT
+cat > "$TMPFILE"
+
+CMD=$(python3 -c "
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data.get('tool_input', {}).get('command', ''))
+" "$TMPFILE" 2>/dev/null || echo "")
+
+# Only intercept git commit and git push
+if [[ "$CMD" != git\ commit* && "$CMD" != git\ push* ]]; then
+    exit 0
+fi
+
+echo "Running pre-commit checks..." >&2
+cd "$CLAUDE_PROJECT_DIR"
+
+if ! make test > "$LOG" 2>&1; then
+    echo "=== make test FAILED ===" >&2
+    cat "$LOG" >&2
+    echo "Fix failing tests before committing." >&2
+    exit 2
+fi
+
+if ! make build > "$LOG" 2>&1; then
+    echo "=== make build FAILED ===" >&2
+    cat "$LOG" >&2
+    echo "Fix build errors before committing." >&2
+    exit 2
+fi
+
+if ! make vet > "$LOG" 2>&1; then
+    echo "=== make vet FAILED ===" >&2
+    cat "$LOG" >&2
+    echo "Fix vet issues before committing." >&2
+    exit 2
+fi
+
+echo "All checks passed." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(git push origin main)",
+      "Bash(git push origin develop)",
+      "Bash(git push --force origin main)",
+      "Bash(git push --force origin develop)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/gofmt.sh",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/test-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/building-message-pipelines/SKILL.md
+++ b/.claude/skills/building-message-pipelines/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: building-message-pipelines
+description: |
+  Provides expertise in the message package architecture for building CloudEvents-based
+  pipelines in gopipe. Apply when working with the message package, Engine, Router,
+  Handler, Matcher, or designing event-driven systems.
+user-invocable: false
+---
+
+# Building Message Pipelines
+
+## Architecture: Single Merger
+
+```
+RawInputs → Unmarshal ─┐
+                       ├→ Merger → Router → Distributor
+TypedInputs ───────────┘                          │
+                                       ┌──────────┴──────────┐
+                                 TypedOutput            RawOutput
+```
+
+Each raw input has its own unmarshal pipe feeding into a single shared merger.
+
+## Engine Configuration
+
+```go
+engine := message.NewEngine(message.EngineConfig{
+    Marshaler:       message.NewJSONMarshaler(),
+    ShutdownTimeout: 5 * time.Second,
+})
+```
+
+## Adding Handlers
+
+```go
+engine.AddHandler("handler-name", matcher, message.NewCommandHandler(
+    func(ctx context.Context, cmd InputType) ([]OutputType, error) {
+        return []OutputType{{...}}, nil
+    },
+    message.CommandHandlerConfig{
+        Source: "/source",
+        Naming: message.DotNaming,
+    },
+))
+```
+
+## Handler Interface
+
+```go
+type Handler interface {
+    EventType() string          // CE type for routing (e.g., "order.created")
+    NewInput() any              // Creates instance for unmarshaling
+    Handle(ctx context.Context, msg *Message) ([]*Message, error)
+}
+```
+
+## Matcher Interface
+
+```go
+type Matcher interface {
+    Match(attrs Attributes) bool  // Attributes only — not *Message
+}
+```
+
+Operates on Attributes only (not `*Message`) to avoid wrapper allocation for raw messages.
+
+## Inputs and Outputs
+
+```go
+// Raw input ([]byte data)
+input := make(chan *message.RawMessage, 10)
+engine.AddRawInput("name", matcher, input)
+
+// Raw output
+output, _ := engine.AddRawOutput("name", matcher)
+
+// Typed input
+typedInput := make(chan *message.Message, 10)
+engine.AddInput("name", matcher, typedInput)
+
+// Typed output
+typedOutput, _ := engine.AddOutput("name", matcher)
+```
+
+## Loopback is a Plugin
+
+Loopback is NOT built into Engine. Use `plugin.Loopback`:
+
+```go
+engine.AddPlugin(plugin.Loopback("step1-loop", &typeMatcher{"step1.completed"}))
+```
+
+## Event Type Naming
+
+| Naming | Output | Example |
+|--------|--------|---------|
+| `DotNaming` | `type.subtype` | `order.created` |
+| `KebabNaming` | `type-subtype` | `order-created` |
+| `SnakeNaming` | `type_subtype` | `order_created` |
+
+## Graceful Shutdown
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+done, _ := engine.Start(ctx)
+
+close(input)  // Close inputs first
+cancel()      // Then cancel context
+<-done        // Wait for shutdown
+```
+
+## Rejected Alternatives
+
+**Combined Marshaler with Registry** — rejected: single responsibility. Marshaler is pure serialization; `Handler.NewInput()` provides instances.
+
+**PipeHandler Interface** — rejected: over-engineering. `EventType()` returning `"*"` for multi-type is a hack.
+
+**Named Outputs with RouteOutput** — rejected: pattern matching on CE type is more declarative.
+
+## Reference Procedures
+
+- @../AGENTS.md — full architecture decisions and rejected alternatives
+- @../message/doc.go — package documentation
+- @../docs/adr/ — Architecture Decision Records

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: changelog
+description: Add an entry to the CHANGELOG under [Unreleased]. Usage: /changelog TYPE DESC (e.g. /changelog Added support for Redis adapter)
+allowed-tools:
+  - Read
+  - Edit
+---
+
+# Changelog
+
+Add a CHANGELOG entry for: `$ARGUMENTS`
+
+## Steps
+
+1. Read `CHANGELOG.md` to find the `[Unreleased]` section
+2. Parse arguments: first word is the subsection type (`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`), rest is the description
+3. Add a bullet point under the correct subsection within `[Unreleased]`
+   - Create the subsection header if it doesn't exist yet
+   - Keep alphabetical order of subsections: Added → Changed → Deprecated → Fixed → Removed
+4. Report the line added
+
+## CHANGELOG Format
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- New feature description
+
+### Fixed
+
+- Bug fix description
+```
+
+If `$ARGUMENTS` does not start with a recognized subsection type, ask the user to clarify.

--- a/.claude/skills/create-adr/SKILL.md
+++ b/.claude/skills/create-adr/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: create-adr
+description: Create a new Architecture Decision Record. Usage: /create-adr TITLE (e.g. /create-adr add-redis-adapter)
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+---
+
+# Create ADR
+
+Create an ADR for: `$ARGUMENTS`
+
+Follow the procedure: @../docs/procedures/adr.md
+
+## Steps
+
+1. Read `docs/adr/README.md` to get the next sequential number
+2. Create `docs/adr/NNNN-<slugified-title>.md` using the template from the procedure
+3. Fill in:
+   - `Date:` today's date
+   - `Status: Proposed`
+   - `Context:` describe the problem or situation
+   - `Decision:` placeholder (to be filled)
+   - `Consequences:` placeholder (to be filled)
+4. Add entry to `docs/adr/README.md` index under **Proposed** status
+5. Report the file path created
+
+Use the title from arguments as the ADR title. Slugify it for the filename (lowercase, hyphens).

--- a/.claude/skills/create-feature/SKILL.md
+++ b/.claude/skills/create-feature/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: create-feature
+description: Create a new feature branch from develop. Usage: /create-feature NAME (e.g. /create-feature message-validation)
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+---
+
+# Create Feature
+
+Create feature branch from develop for: `$ARGUMENTS`
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feature/$ARGUMENTS
+```
+
+Confirm the branch was created and report: `git status` + current branch name.

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: create-plan
+description: Create a new implementation plan document. Usage: /create-plan TITLE (e.g. /create-plan redis-adapter)
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+---
+
+# Create Plan
+
+Create an implementation plan for: `$ARGUMENTS`
+
+Follow the procedure: @../docs/procedures/planning.md
+
+## Steps
+
+1. Read `docs/plans/README.md` to determine the next number (look at archive/ for highest used)
+2. Create `docs/plans/<descriptive-name>.md` (active plans use descriptive names, not numbers)
+3. Fill in the plan template:
+   - `Status: Proposed`
+   - `Overview:` brief description
+   - `Goals:` list of goals
+   - `Tasks:` one task section per major work item
+   - `Implementation Order:` dependency diagram or list
+   - `Acceptance Criteria:` completion checklist
+4. Update `docs/plans/README.md` index with the new plan under the current initiatives table
+5. If related ADRs exist, link them (and update the ADR's Links section)
+6. Report the file path created
+
+Use the title from arguments to derive the descriptive filename (lowercase, hyphens).

--- a/.claude/skills/developing-go-code/SKILL.md
+++ b/.claude/skills/developing-go-code/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: developing-go-code
+description: |
+  Provides Go development standards and best practices for the gopipe codebase.
+  Apply when writing or reviewing Go code: testing patterns, godoc, error handling,
+  API conventions, and common anti-patterns to avoid.
+user-invocable: false
+---
+
+# Developing Go Code
+
+## Build Commands
+
+```bash
+make test   # Run all tests
+make build  # Build all packages
+make vet    # Run linters
+make check  # All of the above
+```
+
+## API Conventions
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Constructors | Config struct | `NewEngine(EngineConfig{})` |
+| Methods | Direct parameters | `AddHandler("name", matcher, h)` |
+| Optional filtering | `nil` = match all | `AddOutput("out", nil)` |
+
+## Godoc Standards
+
+First sentence starts with the function name and describes what it does. Include a usage example for non-trivial functions:
+
+```go
+// GroupBy aggregates items from the input channel by key, emitting batches
+// when size or time limits are reached.
+//
+// Example:
+//
+//	groups := channel.GroupBy(orders, func(o Order) string {
+//	    return o.CustomerID
+//	}, channel.GroupByConfig{MaxSize: 10})
+func GroupBy[K comparable, V any](...) <-chan Group[K, V]
+```
+
+## Testing
+
+- Table-driven tests preferred
+- Use `t.Parallel()` where safe
+- Test both success and error paths
+- Mock external dependencies
+- Run with `-race` flag: `go test -race ./...`
+
+## Error Handling
+
+- Return errors, don't panic (except in `Must*` functions)
+- Wrap with context: `fmt.Errorf("operation: %w", err)`
+- Check errors immediately after call
+
+## Common Mistakes to Avoid
+
+### Using channel.Process for filtering
+
+```go
+// WRONG - Process is for 1:N mapping
+channel.Process(in, func(msg) []*Message {
+    if match { return []*Message{msg} }
+    return nil
+})
+
+// CORRECT - Filter with side effect
+channel.Filter(in, func(msg) bool {
+    if matcher.Match(msg) { return true }
+    errorHandler(msg, ErrRejected)
+    return false
+})
+```
+
+### Creating components in Start()
+
+```go
+// WRONG - creates forwarding complexity
+func (e *Engine) Start() {
+    e.distributor = NewDistributor()
+}
+
+// CORRECT - create upfront so Add* works before Start
+func NewEngine() *Engine {
+    return &Engine{distributor: NewDistributor()}
+}
+```
+
+### Handler.Name() method
+
+Handler should NOT own its name — name is a wiring concern:
+
+```go
+// WRONG
+type Handler interface { Name() string }
+
+// CORRECT - name is parameter to AddHandler
+engine.AddHandler("process-orders", matcher, handler)
+```
+
+### Copy() sharing Attributes map
+
+```go
+// WRONG - modifications affect original
+return &Message{Attributes: msg.Attributes}
+
+// CORRECT - clone for independence
+return &Message{Attributes: maps.Clone(msg.Attributes)}
+```
+
+## Reference Procedures
+
+- @../docs/procedures/go.md — full Go standards, deprecation, error handling
+- @../AGENTS.md — architecture decisions, common mistakes, naming decisions

--- a/.claude/skills/docs-lint/SKILL.md
+++ b/.claude/skills/docs-lint/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: docs-lint
+description: Check documentation quality and consistency across the project.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Docs Lint
+
+Run the documentation lint procedure: @../docs/procedures/documentation.md
+
+Execute each step and report issues found:
+
+1. **Broken internal links** — scan all markdown links in `docs/`, verify targets exist
+2. **ADR index** — compare `docs/adr/*.md` files with `docs/adr/README.md` entries; check status consistency
+3. **Procedures index** — compare `docs/procedures/*.md` with `docs/procedures/README.md`
+4. **CHANGELOG** — verify `[Unreleased]` section exists, version sections have dates, no duplicates
+5. **Plans index** — compare `docs/plans/*.md` (active) and `docs/plans/archive/*.md` with `docs/plans/README.md`
+
+Output a summary report:
+
+```
+Documentation Lint Report
+=========================
+[ ] Broken links: X found
+[ ] ADR index: X missing, X stale
+[ ] Procedures index: X missing, X stale
+[ ] CHANGELOG: OK / Issues
+[ ] Plans index: X missing, X stale
+```
+
+List specific issues with file paths so they can be fixed.

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: hotfix
+description: Create and release a hotfix branch. Usage: /hotfix NAME (e.g. /hotfix fix-nil-panic)
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Hotfix
+
+Create and release a hotfix for: `$ARGUMENTS`
+
+Read the full procedure before starting: @../docs/procedures/release.md
+
+## Steps
+
+**Create hotfix branch:**
+1. `git checkout main && git pull origin main`
+2. `git checkout -b hotfix/$ARGUMENTS`
+
+**Implement fix:**
+3. Explore the issue, implement the minimal fix
+4. Add tests if applicable
+5. Update CHANGELOG with new version section
+6. `make check` must pass
+
+**Commit and PR:**
+7. Commit with `fix: description`
+8. `git push -u origin hotfix/$ARGUMENTS`
+9. `gh pr create --base main --title "fix: description"`
+
+**Release:**
+10. **PAUSE: ask for approval before merge**
+11. `gh pr merge --merge`
+12. `git checkout main && git pull origin main`
+13. **PAUSE: ask for approval before creating tags**
+14. Determine next patch version (`make version`)
+15. Create and push module tags in order: channel → pipe → message
+16. **PAUSE: ask for approval before pushing tags**
+17. Create GitHub release
+18. Merge main back to develop
+
+## Rules
+
+- Hotfixes branch from main, not develop
+- Fix only the reported issue — no scope creep
+- Never skip an approval gate
+- Resolve CHANGELOG conflicts when merging main to develop (keep [Unreleased] at top)

--- a/.claude/skills/managing-git-workflow/SKILL.md
+++ b/.claude/skills/managing-git-workflow/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: managing-git-workflow
+description: |
+  Provides expertise in git flow procedures for the gopipe multi-module Go repository.
+  Apply when working with git operations, branch management, releases, or multi-module
+  tagging. Covers branch naming, commit conventions, approval gates, and tag ordering.
+user-invocable: false
+---
+
+# Managing Git Workflow
+
+## Branch Naming
+
+| Branch | Purpose | Base |
+|--------|---------|------|
+| `feature/*` | New features | develop |
+| `release/*` | Release preparation | develop |
+| `hotfix/*` | Critical fixes | main |
+| `claude/*` | Claude-generated branches | develop |
+
+## Commit Conventions
+
+Conventional commits required: `<type>(<scope>): <description>`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Examples:
+```
+feat(message): add CloudEvents validation
+fix(router): handle nil handler gracefully
+docs: update architecture roadmap
+```
+
+## Multi-Module Tagging
+
+Tag in dependency order — Go proxy resolves from published tags:
+
+1. `channel/vX.Y.Z` — no internal dependencies
+2. `pipe/vX.Y.Z` — depends on channel
+3. `message/vX.Y.Z` — depends on channel and pipe
+4. `examples/vX.Y.Z` — optional
+
+Push all at once: `git push origin channel/vX.Y.Z pipe/vX.Y.Z message/vX.Y.Z`
+
+## Approval Gates
+
+**Always pause and ask for explicit approval before:**
+- Interactive rebase or history rewrite
+- Force push to any branch
+- Merge to develop or main
+- Creating or pushing tags
+- Creating GitHub releases
+
+## Key Rules
+
+- Never merge directly to main — always PRs through develop
+- Never force push to main or develop
+- Run `make test && make build && make vet` before push
+- Document before push: CHANGELOG, ADRs, godoc
+
+## Common Mistakes
+
+- Tagging out of order (channel must precede pipe, pipe must precede message)
+- Forgetting to sync develop after release (`git merge main` → develop)
+- Force pushing without lease (`--force` instead of `--force-with-lease`)
+
+## Reference Procedures
+
+- @../docs/procedures/git.md — branch naming, commits, version management
+- @../docs/procedures/feature-release.md — full merge workflow with approval gates
+- @../docs/procedures/release.md — tagging, hotfixes, multi-module release

--- a/.claude/skills/release-feature/SKILL.md
+++ b/.claude/skills/release-feature/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: release-feature
+description: Merge a feature branch to develop following the git flow procedure (history cleanup, PR, verify).
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Release Feature
+
+Execute Phases 1–3 of the Feature Branch Release Procedure for branch: `$ARGUMENTS`
+
+Read the full procedure before starting: @../docs/procedures/feature-release.md
+
+## Steps
+
+**Phase 1 — History cleanup:**
+1. Review commit history since branching from develop
+2. Plan logical, atomic commit structure
+3. **PAUSE: ask for approval before rebase**
+4. Interactive rebase to clean history
+5. Verify `make check` passes after rebase
+6. **PAUSE: ask for approval before force push**
+7. `git push --force-with-lease origin <branch>`
+
+**Phase 2 — Merge to develop:**
+1. Rebase onto latest develop
+2. Create PR: `gh pr create --base develop ...`
+3. Show PR checks and diff summary
+4. **PAUSE: ask for approval before merge**
+5. `gh pr merge --merge --delete-branch`
+
+**Phase 3 — Verify develop:**
+1. `git checkout develop && git pull origin develop`
+2. `make check`
+3. Report success
+
+## Rules
+
+- Never skip an approval gate
+- Show diffs before merges (`gh pr diff`)
+- Show current history before proposing rebase plan
+- Use conventional commit format in rebase

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: release
+description: Release develop to main with multi-module tags and GitHub release. Usage: /release VERSION (e.g. /release v0.13.0)
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+---
+
+# Release
+
+Execute Phases 4–6 of the Feature Branch Release Procedure for version: `$ARGUMENTS`
+
+Read the full procedure before starting: @../docs/procedures/release.md
+
+## Steps
+
+**Phase 4 — Merge to main:**
+1. Check for cross-module API changes: `git diff vOLD..HEAD -- channel/ pipe/`
+2. Update CHANGELOG: move [Unreleased] to new version section with date
+3. Create release PR: `gh pr create --base main --head develop --title "release: VERSION"`
+4. Show PR checks
+5. **PAUSE: ask for approval before merge**
+6. `gh pr merge --merge`
+
+**Phase 5 — Tag and release:**
+1. `git checkout main && git pull origin main`
+2. Determine if go.mod refs need updating (cross-module API changes?)
+3. **PAUSE: ask for approval before creating tags**
+4. Create tags in dependency order: `channel/VERSION`, `pipe/VERSION`, `message/VERSION`
+5. **PAUSE: ask for approval before pushing tags**
+6. Push module tags + bare version tag
+7. `gh release create VERSION --title "VERSION" --notes "..."`
+
+**Phase 6 — Post-release:**
+1. `git checkout develop && git merge main && git push origin develop`
+2. Verify module publication: `go list -m github.com/fxsml/gopipe/channel@VERSION`
+3. Report release URL
+
+## Rules
+
+- Never skip an approval gate
+- Tag in dependency order: channel → pipe → message
+- Check cross-module API changes before deciding whether to update go.mod refs
+- Merge back to develop after release

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: review-pr
+description: Review a pull request against gopipe project standards. Usage: /review-pr [NUMBER] (omit for current branch PR)
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+---
+
+# Review PR
+
+Review PR `$ARGUMENTS` (or the current branch PR if no number given) against gopipe standards.
+
+## Steps
+
+1. Fetch PR details:
+   ```bash
+   gh pr view $ARGUMENTS
+   gh pr diff $ARGUMENTS
+   gh pr checks $ARGUMENTS
+   ```
+
+2. Review against each checklist item below and report pass/fail with specific line references
+
+## Review Checklist
+
+### Code Quality
+- [ ] No use of `channel.Process` for filtering (use `channel.Filter`)
+- [ ] Components created in constructor, not in `Start()`
+- [ ] Handler does not own its name (name is passed to `AddHandler`)
+- [ ] `Copy()` clones Attributes map (`maps.Clone`)
+- [ ] Matcher operates on `Attributes`, not `*Message`
+- [ ] Errors returned, not panicked (except `Must*` functions)
+- [ ] Errors wrapped with context: `fmt.Errorf("op: %w", err)`
+
+### Tests
+- [ ] Table-driven tests for multiple cases
+- [ ] Both success and error paths tested
+- [ ] `t.Parallel()` used where safe
+- [ ] New public APIs have tests
+
+### Documentation
+- [ ] Public APIs have godoc (first sentence starts with function name)
+- [ ] CHANGELOG.md updated under `[Unreleased]`
+- [ ] ADR created for architectural decisions (API changes, new interfaces)
+- [ ] No breaking changes without ADR
+
+### Git
+- [ ] Conventional commit messages (`feat:`, `fix:`, `docs:`, etc.)
+- [ ] No merge commits in feature branch history
+- [ ] PR targets `develop`, not `main`
+
+## Output Format
+
+Report as:
+```
+PR #N Review: <title>
+
+PASS ✓ / FAIL ✗ / N/A for each checklist item
+
+Issues found:
+- <specific issue with file:line reference>
+
+Overall: APPROVED / CHANGES REQUESTED
+```

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: verify
+description: Run the full pre-push verification suite (make test, build, vet).
+allowed-tools:
+  - Bash
+---
+
+# Verify
+
+Run the pre-push checklist:
+
+```bash
+make test
+make build
+make vet
+```
+
+Report pass/fail for each step. If any step fails, show the relevant error output and suggest the fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,40 @@ make vet    # Run linters
 3. **Document before push** — Features, ADRs, CHANGELOG
 4. **Test before push** — `make test && make build && make vet`
 
+## Claude Code Integration
+
+See `.claude/CLAUDE.md` for the full Claude Code configuration.
+
+### Auto-Applied Skills
+
+Domain expertise loaded automatically from `.claude/skills/`:
+
+| Skill | Expertise Area |
+|-------|----------------|
+| `managing-git-workflow` | Git flow, branch naming, multi-module tagging, approval gates |
+| `developing-go-code` | Go standards, testing, common anti-patterns |
+| `building-message-pipelines` | Message package architecture, Engine, Router, Handler |
+
+### Slash Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/release-feature BRANCH` | Merge feature branch to develop (history cleanup → PR → verify) |
+| `/release VERSION` | Release develop to main with multi-module tags |
+| `/hotfix NAME` | Create and release a hotfix from main |
+| `/create-feature NAME` | Create feature branch from develop |
+| `/verify` | Run `make test && make build && make vet` |
+| `/docs-lint` | Check documentation quality and index consistency |
+| `/create-adr TITLE` | Create new Architecture Decision Record |
+| `/create-plan TITLE` | Create implementation plan |
+| `/changelog TYPE DESC` | Add entry to CHANGELOG under [Unreleased] |
+| `/review-pr [NUMBER]` | Review PR against project standards |
+
+### Hooks
+
+- **PostToolUse**: `gofmt -w` runs automatically after editing any `.go` file
+- **PreToolUse**: `make test && make build && make vet` runs before `git commit` or `git push`
+
 ## Package Overview
 
 | Package | Purpose | Key Types |


### PR DESCRIPTION
## Summary

- Add `.claude/CLAUDE.md` importing `AGENTS.md` and all procedure files
- Add 10 slash command skills (`/release-feature`, `/release`, `/hotfix`, `/create-feature`, `/verify`, `/docs-lint`, `/create-adr`, `/create-plan`, `/changelog`, `/review-pr`)
- Add 3 auto-applied domain skills (`managing-git-workflow`, `developing-go-code`, `building-message-pipelines`)
- Add hooks in `settings.json`: `gofmt -w` on `.go` edits, `make test/build/vet` guard before `git commit`/`git push`
- Add `settings.json` with deny list for direct pushes to `main`/`develop`
- Add `AGENTS.md` with quick commands, key rules, and architecture overview for AI agents

## Commits

4a206d5 feat: add Claude Code skills, hooks, and CLAUDE.md integration

## Test plan

- [ ] `make test && make build && make vet` passes
- [ ] Skills load correctly in Claude Code session
- [ ] Hooks execute on `.go` file edits and `git commit`/`git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)