### PR TITLE
fix(message): return error on command handler type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for `>= 500` writes generic `http.StatusText` to avoid leaking internals, for `< 500` writes `err.Error()`
   - All default responses are JSON: `{"error":"<message>"}` with `Content-Type: application/json`
 
+### Fixed
+
+- **message:** `commandHandler.Handle` now returns `ErrCommandDataMismatch` instead
+  of silently falling back to a zero-value command when `msg.Data` is `nil` or does
+  not type-assert to `*C`/`C` (#145)
+
 ## [0.18.0] - 2026-04-10
 
 ### Added

--- a/message/errors.go
+++ b/message/errors.go
@@ -20,4 +20,8 @@ var (
 
 	// ErrHandlerExists is returned when registering a handler for an event type that already has one.
 	ErrHandlerExists = errors.New("handler already registered for event type")
+
+	// ErrCommandDataMismatch is returned when a commandHandler's message data is nil
+	// or does not type-assert to the expected command type.
+	ErrCommandDataMismatch = errors.New("command data type mismatch")
 )

--- a/message/handler.go
+++ b/message/handler.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"reflect"
 	"time"
@@ -103,12 +104,13 @@ func (h *commandHandler[C, E]) NewInput() any {
 
 func (h *commandHandler[C, E]) Handle(ctx context.Context, msg *Message) ([]*Message, error) {
 	var cmd C
-	if msg.Data != nil {
-		if v, ok := msg.Data.(*C); ok {
-			cmd = *v
-		} else if v, ok := msg.Data.(C); ok {
-			cmd = v
-		}
+	switch v := msg.Data.(type) {
+	case *C:
+		cmd = *v
+	case C:
+		cmd = v
+	default:
+		return nil, fmt.Errorf("%w: got %T, want %T", ErrCommandDataMismatch, msg.Data, cmd)
 	}
 
 	events, err := h.fn(ctx, cmd)

--- a/message/handler_test.go
+++ b/message/handler_test.go
@@ -155,6 +155,42 @@ func TestNewCommandHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("returns error for nil data", func(t *testing.T) {
+		h := NewCommandHandler(
+			func(ctx context.Context, cmd TestCommand) ([]TestEvent, error) {
+				return nil, nil
+			},
+			CommandHandlerConfig{
+				Source: "/test",
+				Naming: DotNaming,
+			},
+		)
+
+		msg := &Message{Data: nil}
+		_, err := h.Handle(context.Background(), msg)
+		if !errors.Is(err, ErrCommandDataMismatch) {
+			t.Fatalf("expected ErrCommandDataMismatch, got %v", err)
+		}
+	})
+
+	t.Run("returns error for mismatched data type", func(t *testing.T) {
+		h := NewCommandHandler(
+			func(ctx context.Context, cmd TestCommand) ([]TestEvent, error) {
+				return nil, nil
+			},
+			CommandHandlerConfig{
+				Source: "/test",
+				Naming: DotNaming,
+			},
+		)
+
+		msg := &Message{Data: &TestEvent{ID: "wrong-type"}}
+		_, err := h.Handle(context.Background(), msg)
+		if !errors.Is(err, ErrCommandDataMismatch) {
+			t.Fatalf("expected ErrCommandDataMismatch, got %v", err)
+		}
+	})
+
 	t.Run("attributes available via message in context", func(t *testing.T) {
 		var ctxMsg *Message
 		h := NewCommandHandler(


### PR DESCRIPTION
commandHandler.Handle silently fell back to a zero-value command when
msg.Data was nil or didn't type-assert to *C/C, masking wiring bugs
instead of surfacing them through the normal error path. Now returns
ErrCommandDataMismatch, consistent with the package's other sentinel
errors (ErrNoHandler, ErrUnknownType, etc.).

Fixes #145