### PR TITLE
docs: plan Engine removal, raw-by-default Message contract, and dependency policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ Load these on demand when the relevant task arises:
 | Documentation, CHANGELOG, doc linting | @../docs/procedures/documentation.md |
 | Planning and plan documents | @../docs/procedures/planning.md |
 | ADR creation and lifecycle | @../docs/procedures/adr.md |
+| Dependency and package boundary decisions | @../docs/procedures/dependencies.md |
 | Feature branch merge (history cleanup) | @../docs/procedures/feature-release.md |
 | Release and multi-module tagging | @../docs/procedures/release.md |
 

--- a/docs/adr/0027-json-schema-validation.md
+++ b/docs/adr/0027-json-schema-validation.md
@@ -1,7 +1,7 @@
 # ADR 0027: JSON Schema Validation
 
 **Date:** 2026-02-16
-**Status:** Implemented
+**Status:** Superseded by ADR 0028
 
 ## Context
 
@@ -288,3 +288,9 @@ engine := message.NewEngine(message.EngineConfig{
 4. **Validation caching** - Cache validation results for identical payloads
 5. **Schema references** - Support `$ref` across registered schemas
 6. **Metrics** - Validation success/failure counters for observability
+
+## Updates
+
+**2026-07-26:** Superseded by ADR 0028 (External Dependency Policy). `message/jsonschema` is removed, not kept: the `Registry` maintains its own eventType↔Go-type mapping (`types`/`reverse`, populated via `RegisterType`) fully independent of `Router`'s own eventType→handler registry — a second, parallel source of truth for the same conceptual fact, with its own separately-configurable `EventTypeNaming` that can silently drift out of sync with `Router`'s. This is a real-world-proven pain point, not a hypothetical one. `santhosh-tekuri/jsonschema/v6` itself remains a reasonable dependency on its own merits (this ADR's library comparison table still holds); the wrapper `Registry`/middleware built around it in this package is what's being removed. Applications that need JSON Schema validation can depend on `santhosh-tekuri/jsonschema` directly.
+
+**Example replacement, decided, not a like-for-like port:** rather than leave this as an unguided "implement it yourself," `examples/07-validating-marshaler` is rewritten to demonstrate a `Marshaler`-decorator pattern — a `ValidatingMarshaler` wrapping `message.Marshaler` that keys schemas by `reflect.Type` (the same type `Router` already resolves via `Handler.NewInput()`) instead of a separately-derived CloudEvents type string. This sidesteps the naming-strategy-drift failure mode structurally, not just by convention, since there's no independent naming step to drift. It's deliberately *not* a shipped package — no `InputRegistry`, no schema-catalog HTTP serving, no proxy (no-Go-type) validation support; those are real capabilities this trades away, not oversights. Whether shipped JSON Schema support as a package ever comes back is a separate, distant, open question — not a qualifier on the removal or the example replacement, both of which are settled here.

--- a/docs/adr/0028-external-dependency-policy.md
+++ b/docs/adr/0028-external-dependency-policy.md
@@ -1,0 +1,46 @@
+# ADR 0028: External Dependency Policy
+
+**Date:** 2026-07-26
+**Status:** Proposed
+
+## Context
+
+gopipe is a multi-module repository: `channel`, `pipe`, `message`, `message`'s subpackages (`http`, `cloudevents`, `jsonschema`, `match`, `middleware`), and the separately-versioned `message/otel`. Reviewing the marshaling-strategy work ([#125](https://github.com/fxsml/gopipe/issues/125), [#147](https://github.com/fxsml/gopipe/issues/147)–[#149](https://github.com/fxsml/gopipe/issues/149)) and its knock-on findings ([#151](https://github.com/fxsml/gopipe/issues/151)–[#154](https://github.com/fxsml/gopipe/issues/154)) surfaced recurring, previously undocumented questions about which modules may depend on external libraries, and which external-ecosystem bridges belong in this repository at all. Without an explicit policy these decisions were made ad hoc: core `message`'s `go.mod` pulled in `cloudevents/sdk-go` and `santhosh-tekuri/jsonschema` for every consumer regardless of need, and `message/otel` was split into a same-repo module (unreleased, unproven) rather than following the separate-repo convention already established by `gopipe-azservicebus`.
+
+## Decision
+
+Four rules govern dependencies and package placement across the repository:
+
+1. **`channel` and `pipe` allow zero external dependencies — including test-only dependencies.** Standard library only, no exceptions. These are the foundational modules; every other module depends on them, so anything pulled in here propagates everywhere. (Verified currently true: `channel/go.mod` has no `require` block at all; `pipe/go.mod` requires only `channel`.)
+
+2. **`message` (core) allows external dependencies, but only curated and individually justified ones** — each weighed for real benefit against its cost (transitive footprint, maintenance burden, fit with gopipe's own stdlib-first conventions). `google/uuid` is the reference example: small, stable, clear benefit, no controversy.
+
+3. **No gopipe package's public API may ever expose a type from an external library.** If a package's contract requires a consumer to also import a third-party SDK directly (e.g. `cloudevents.Event`, `protocol.Receiver`/`Sender`, an OTel `metric.Meter`), that package does not live in this repository — it lives in its own separate repository, following the naming convention already established by `gopipe-azservicebus` (e.g. `gopipe-cloudevents`, `gopipe-otel`).
+
+4. **A subpackage must be stable, mature, and have a demonstrated real-world use case to ship — independent of whether it passes rules 1–3.** Passing the dependency rules is necessary but not sufficient; an immature or effectively-unused abstraction doesn't ship in v1 merely because it's dependency-clean. (`message/match`/`Matcher`'s real-world usage is evaluated under this rule via [#153](https://github.com/fxsml/gopipe/issues/153); `message/middleware`'s five middlewares are evaluated individually, not collectively, since passing rules 1–3 trivially — zero external deps in any of them — doesn't itself satisfy rule 4.)
+
+## Consequences
+
+**Breaking Changes:**
+
+- `message/cloudevents` moves to its own repository (rule 3) — no longer importable as `github.com/fxsml/gopipe/message/cloudevents`.
+- `message/otel` moves to its own repository (rule 3), replacing its current same-repo-module shape.
+- `message/jsonschema` is removed entirely (rule 4), decided, not tentative — its wrapper `Registry` duplicates `Router`'s own eventType→handler bookkeeping in a second, independently-maintained mapping. The underlying `santhosh-tekuri/jsonschema` library itself is not the problem (it passes rule 2 on its own merits) and remains fine to use directly in application code; gopipe just stops shipping an abstraction around it. `examples/07-validating-marshaler` is rewritten (not deleted) to demonstrate the replacement, also decided: a `Marshaler` decorator keying schemas by `reflect.Type` instead of a separately-derived event-type string, sidestepping the naming-drift failure mode structurally rather than by convention. The only open-ended part is further out: whether shipped JSON Schema support as a real package *ever* returns — worth reconsidering only if a future design earns back the schema-catalog/proxy-validation capabilities traded away here without reintroducing a second registry. That's a distant possibility, not a qualifier on the removal itself.
+- `message/http` keeps CloudEvents HTTP protocol binding support, but implements it directly rather than depending on `cloudevents/sdk-go` (rule 2 weighed against it: the SDK's transitive footprint includes a full `zap` logging framework and `json-iterator` alternate JSON encoder, both duplicating capabilities gopipe already has via `message.Logger` and stdlib `encoding/json`). Structured and batch mode reuse existing `message.go` logic (`ParseRaw`/`WriteTo` already implement CloudEvents' structured-mode JSON envelope); binary mode is implemented directly against `*message.RawMessage`.
+
+**Benefits:**
+
+- Consumers of core `github.com/fxsml/gopipe/message` never carry dependencies for features they don't use.
+- Clear, checkable rules for evaluating any future subpackage or dependency addition.
+- `message/http` becomes genuinely zero-dependency — the "batteries included, works without a broker" reference transport, not "zero dependency except transitively."
+
+**Drawbacks:**
+
+- `message/http` owns correctness for CloudEvents HTTP binary-mode encoding (percent-encoding rules, UTF-8 validation) itself, rather than inheriting the official SDK's cross-implementation-tested behavior.
+- More repositories to maintain and release independently (`gopipe-cloudevents`, `gopipe-otel`) instead of one.
+
+## Links
+
+- Related: [#125](https://github.com/fxsml/gopipe/issues/125), [#147](https://github.com/fxsml/gopipe/issues/147), [#148](https://github.com/fxsml/gopipe/issues/148), [#149](https://github.com/fxsml/gopipe/issues/149), [#151](https://github.com/fxsml/gopipe/issues/151), [#152](https://github.com/fxsml/gopipe/issues/152), [#153](https://github.com/fxsml/gopipe/issues/153), [#154](https://github.com/fxsml/gopipe/issues/154)
+- Related: ADR 0020 (Message Engine Architecture), ADR 0022 (Message Package Redesign)
+- Supersedes: ADR 0027 (JSON Schema Validation) — `message/jsonschema` is removed per rule 4's consequences above

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,8 +37,9 @@ See [ADR Procedures](../procedures/adr.md) for details.
 | [0023](0023-engine-simplification.md) | Engine Simplification | Implemented |
 | [0024](0024-http-cloudevents-adapter.md) | HTTP CloudEvents Adapter Design | Implemented |
 | [0025](0025-message-context-values.md) | Message Context for In-Process Values | Proposed |
-| [0027](0027-json-schema-validation.md) | JSON Schema Validation | Implemented |
+| [0027](0027-json-schema-validation.md) | JSON Schema Validation | Superseded by ADR 0028 |
 | [0026](0026-acking-middleware-outermost.md) | Acking Middleware Outermost | Proposed |
+| [0028](0028-external-dependency-policy.md) | External Dependency Policy | Proposed |
 
 ## History
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,6 +6,8 @@
 |------|-------|--------|
 | [pipe-metrics](pipe-metrics.md) | Pipeline Metrics | Complete |
 | [locals](locals.md) | Message Locals | Implemented |
+| [engine-removal](engine-removal.md) | Remove Message Engine | Proposed |
+| [marshaling-strategy](marshaling-strategy.md) | Raw-by-Default Message Contract (Router) | Proposed |
 | [0007](0007-cesql-pattern-matching.md) | CESQL Pattern Matching | Proposed |
 | [autoscale-worker-pool](autoscale-worker-pool.md) | Autoscale Worker Pool | Proposed |
 | [transaction-handling](transaction-handling.md) | Transaction Handling | Proposed |

--- a/docs/plans/engine-removal.md
+++ b/docs/plans/engine-removal.md
@@ -21,7 +21,14 @@ This plan pays off directly: `Engine` currently depends on `RawMessage`/`TypedMe
 
 ## Tasks
 
-### Task 1: Delete Engine core
+### Task 1: Write the ADR (before any deletion)
+
+Write ADR (next available number) — "Remove Message Engine", superseding ADR 0020, `Status: Proposed`/`Accepted`. Documents the decision and gives it a real review point before irreversible deletion happens, rather than writing it after the fact to describe a change that's already landed. Mark `Status: Implemented` once Tasks 2–6 are done (see Acceptance Criteria).
+
+**Acceptance Criteria:**
+- [ ] ADR written and accepted before Task 2 starts
+
+### Task 2: Delete Engine core
 
 **Files to delete:**
 - `message/engine.go`
@@ -32,7 +39,7 @@ This plan pays off directly: `Engine` currently depends on `RawMessage`/`TypedMe
 - [ ] Files removed
 - [ ] `message` package compiles with no remaining reference to `Engine`, `EngineConfig`, or `Plugin`
 
-### Task 2: Delete Engine-dependent CloudEvents plugin wiring
+### Task 3: Delete Engine-dependent CloudEvents plugin wiring
 
 **Files to delete:**
 - `message/cloudevents/plugin.go` (`SubscriberPlugin`, `PublisherPlugin` — pure `Engine`-wiring sugar around `e.AddRawInput`/`e.AddRawOutput`)
@@ -45,7 +52,7 @@ This plan pays off directly: `Engine` currently depends on `RawMessage`/`TypedMe
 - [ ] `message/cloudevents` compiles with no reference to `message.Engine` or `message.Plugin`
 - [ ] `message/cloudevents/doc.go` updated to drop plugin-based usage examples
 
-### Task 3: Rewrite tests that wire through Engine
+### Task 4: Rewrite tests that wire through Engine
 
 **File:** `message/middleware/correlation_test.go`
 
@@ -55,7 +62,7 @@ Tests `CorrelationID()` via four separate `message.NewEngine(...)` constructions
 - [ ] All `CorrelationID()` test cases pass using `Router` directly
 - [ ] No `message.NewEngine` reference remains in the file
 
-### Task 4: Rewrite package docs
+### Task 5: Rewrite package docs
 
 **Files:**
 - `message/doc.go` — "Quick Start" example is `Engine`-based; rewrite to a `Router`-based quick start (handler registration + `Router.Pipe()` over a channel).
@@ -65,7 +72,7 @@ Tests `CorrelationID()` via four separate `message.NewEngine(...)` constructions
 - [ ] No `message.NewEngine`/`Engine` reference remains in either file
 - [ ] Examples in both files compile (verified by doc-testable examples or manual check)
 
-### Task 5: Rewrite example programs
+### Task 6: Rewrite example programs
 
 **Files:**
 - `examples/04-message/main.go`
@@ -77,20 +84,21 @@ Both currently demonstrate `Engine` end-to-end. Rewrite to demonstrate `Router` 
 - [ ] Both examples run (`go run ./04-message/`, `go run ./06-http-cloudevents/`)
 - [ ] Neither references `message.Engine`
 
-### Task 6: ADR and CHANGELOG
+### Task 7: Close out — ADR status and CHANGELOG
 
-- [ ] Write ADR 0028 (next available number) — "Remove Message Engine", superseding ADR 0020, with an `## Updates` note added to ADR 0022 recording that the `Engine` it introduced has since been removed
+- [ ] Mark the Task 1 ADR `Status: Implemented`; add an `## Updates` note to ADR 0022 recording that the `Engine` it introduced has since been removed
 - [ ] CHANGELOG entry under `[Unreleased]` — Removed: `message.Engine`, `message.EngineConfig`, `message.Plugin`, `message/cloudevents.SubscriberPlugin`/`PublisherPlugin` (breaking, pre-v1)
 
 ## Implementation Order
 
 ```
-Task 1 (delete engine.go + tests)
-  → Task 2 (delete cloudevents/plugin.go, depends on Task 1's Plugin type being gone)
-  → Task 3 (rewrite correlation_test.go)
-  → Task 4 (rewrite doc.go, README.md)
-  → Task 5 (rewrite examples)
-  → Task 6 (ADR + CHANGELOG, last — documents the completed change)
+Task 1 (write + accept ADR, before any deletion)
+  → Task 2 (delete engine.go + tests)
+  → Task 3 (delete cloudevents/plugin.go, depends on Task 2's Plugin type being gone)
+  → Task 4 (rewrite correlation_test.go)
+  → Task 5 (rewrite doc.go, README.md)
+  → Task 6 (rewrite examples)
+  → Task 7 (ADR status + CHANGELOG, last — documents the completed change)
 ```
 
 This whole plan must complete before `marshaling-strategy.md`'s Phase 1 (dropping `TypedMessage[T]`/`RawMessage`) starts.
@@ -99,6 +107,6 @@ This whole plan must complete before `marshaling-strategy.md`'s Phase 1 (droppin
 
 - [ ] `make test && make build && make vet` pass with zero references to `Engine`/`EngineConfig`/`Plugin` anywhere in the repository
 - [ ] `Router`, `Merger`, `Distributor` confirmed still independently usable and tested without `Engine`
-- [ ] ADR 0020 marked Superseded; ADR 0022 has an `## Updates` note
+- [ ] ADR written before deletion, marked Implemented after; ADR 0020 marked Superseded; ADR 0022 has an `## Updates` note
 - [ ] CHANGELOG updated
 - [ ] This plan's status updated to Complete

--- a/docs/plans/engine-removal.md
+++ b/docs/plans/engine-removal.md
@@ -1,0 +1,104 @@
+# Plan: Remove Message Engine
+
+**Status:** Proposed
+**Related ADRs:** [0020](../adr/0020-message-engine-architecture.md) (Message Engine Architecture — to be superseded), [0022](../adr/0022-message-package-redesign.md) (Message Package Redesign — needs an Updates note)
+**Depended On By:** [marshaling-strategy.md](marshaling-strategy.md) (its Phase 1 requires this plan complete first)
+**Tracking Issue:** [fxsml/gopipe#147](https://github.com/fxsml/gopipe/issues/147)
+
+## Overview
+
+`Engine` is removed entirely, not kept and mechanically ported. It's the orchestration layer introduced by ADR 0020/0022 — a merger/router/distributor assembly with dedicated per-input/output unmarshal/marshal pipe stages, config-based `AddInput`/`AddRawInput`/`AddOutput`/`AddRawOutput`/`AddPlugin`, and its own shutdown-cascade machinery. In practice it's legacy overengineering: infrastructure built ahead of a real need, adding a whole orchestration layer, a `Plugin` abstraction, and dedicated-pool marshal stages that [marshaling-strategy.md](marshaling-strategy.md) independently concluded were premature.
+
+This plan pays off directly: `Engine` currently depends on `RawMessage`/`TypedMessage[T]`, which [marshaling-strategy.md](marshaling-strategy.md) drops. Rather than spending effort mechanically retyping `Engine` just to keep something already out of scope compiling, this plan removes it outright — which is also why it must land **before** that plan's Phase 1 (dropping `TypedMessage[T]`/`RawMessage` would otherwise break `Engine`'s compile).
+
+`Router`, `Merger`, and `Distributor` are not going anywhere — they're kept as independent, general-purpose components usable without `Engine`. Only the orchestration layer that wired them together automatically is removed.
+
+## Goals
+
+1. Delete `Engine` and its `Plugin` abstraction entirely — no deprecation period, no compatibility shim (pre-v1, single consumer base, consistent with the project's existing "pre-v1, breaking changes acceptable" posture).
+2. Confirm `Merger`/`Distributor` survive unmodified as standalone components (already verified: zero `RawMessage`/`TypedMessage` dependency in either).
+3. Leave no dangling references — every test, example, and doc that wires through `Engine` gets rewritten to use `Router` (+ `Merger`/`Distributor` directly where fan-in/fan-out is actually needed), not just deleted.
+
+## Tasks
+
+### Task 1: Delete Engine core
+
+**Files to delete:**
+- `message/engine.go`
+- `message/engine_test.go`
+- `message/engine_bench_test.go`
+
+**Acceptance Criteria:**
+- [ ] Files removed
+- [ ] `message` package compiles with no remaining reference to `Engine`, `EngineConfig`, or `Plugin`
+
+### Task 2: Delete Engine-dependent CloudEvents plugin wiring
+
+**Files to delete:**
+- `message/cloudevents/plugin.go` (`SubscriberPlugin`, `PublisherPlugin` — pure `Engine`-wiring sugar around `e.AddRawInput`/`e.AddRawOutput`)
+- `message/cloudevents/plugin_test.go`
+
+**Kept, unaffected:** `message/cloudevents/subscriber.go`, `publisher.go`, `adapter.go` — these produce/consume raw channels directly and were never `Engine`-dependent. (They still need their own separate `*RawMessage`→`*Message` mechanical port under `marshaling-strategy.md`, unrelated to this task.)
+
+**Acceptance Criteria:**
+- [ ] Files removed
+- [ ] `message/cloudevents` compiles with no reference to `message.Engine` or `message.Plugin`
+- [ ] `message/cloudevents/doc.go` updated to drop plugin-based usage examples
+
+### Task 3: Rewrite tests that wire through Engine
+
+**File:** `message/middleware/correlation_test.go`
+
+Tests `CorrelationID()` via four separate `message.NewEngine(...)` constructions. Rewrite to construct a `Router` directly and drive it through `Router.Pipe()` — the middleware under test doesn't need `Engine`'s orchestration at all.
+
+**Acceptance Criteria:**
+- [ ] All `CorrelationID()` test cases pass using `Router` directly
+- [ ] No `message.NewEngine` reference remains in the file
+
+### Task 4: Rewrite package docs
+
+**Files:**
+- `message/doc.go` — "Quick Start" example is `Engine`-based; rewrite to a `Router`-based quick start (handler registration + `Router.Pipe()` over a channel).
+- `message/README.md` — has a full "Engine Architecture" section (diagram + three `Engine` code examples: raw I/O, typed I/O, dynamic input/output). Needs a real rewrite, not a trim: describe `Router` (+ `Merger`/`Distributor` as optional standalone fan-in/fan-out) as the supported composition pattern.
+
+**Acceptance Criteria:**
+- [ ] No `message.NewEngine`/`Engine` reference remains in either file
+- [ ] Examples in both files compile (verified by doc-testable examples or manual check)
+
+### Task 5: Rewrite example programs
+
+**Files:**
+- `examples/04-message/main.go`
+- `examples/06-http-cloudevents/main.go`
+
+Both currently demonstrate `Engine` end-to-end. Rewrite to demonstrate `Router` directly (composed with `message/cloudevents` `Subscriber`/`Publisher` for the HTTP example), or drop if no longer representative of a supported pattern.
+
+**Acceptance Criteria:**
+- [ ] Both examples run (`go run ./04-message/`, `go run ./06-http-cloudevents/`)
+- [ ] Neither references `message.Engine`
+
+### Task 6: ADR and CHANGELOG
+
+- [ ] Write ADR 0028 (next available number) — "Remove Message Engine", superseding ADR 0020, with an `## Updates` note added to ADR 0022 recording that the `Engine` it introduced has since been removed
+- [ ] CHANGELOG entry under `[Unreleased]` — Removed: `message.Engine`, `message.EngineConfig`, `message.Plugin`, `message/cloudevents.SubscriberPlugin`/`PublisherPlugin` (breaking, pre-v1)
+
+## Implementation Order
+
+```
+Task 1 (delete engine.go + tests)
+  → Task 2 (delete cloudevents/plugin.go, depends on Task 1's Plugin type being gone)
+  → Task 3 (rewrite correlation_test.go)
+  → Task 4 (rewrite doc.go, README.md)
+  → Task 5 (rewrite examples)
+  → Task 6 (ADR + CHANGELOG, last — documents the completed change)
+```
+
+This whole plan must complete before `marshaling-strategy.md`'s Phase 1 (dropping `TypedMessage[T]`/`RawMessage`) starts.
+
+## Acceptance Criteria
+
+- [ ] `make test && make build && make vet` pass with zero references to `Engine`/`EngineConfig`/`Plugin` anywhere in the repository
+- [ ] `Router`, `Merger`, `Distributor` confirmed still independently usable and tested without `Engine`
+- [ ] ADR 0020 marked Superseded; ADR 0022 has an `## Updates` note
+- [ ] CHANGELOG updated
+- [ ] This plan's status updated to Complete

--- a/docs/plans/marshaling-strategy.md
+++ b/docs/plans/marshaling-strategy.md
@@ -81,7 +81,7 @@ func NewUnmarshalPipe(registry InputRegistry, marshaler Marshaler, cfg PipeConfi
     p.inner = pipe.NewProcessPipe(func(ctx context.Context, msg *Message) ([]*Message, error) {
         raw, ok := msg.Raw()
         if !ok {
-            return nil, fmt.Errorf("%w: got %T", ErrExpectedRawData, msg.Data)
+            return nil, fmt.Errorf("%w: got %T", ErrDataNotRaw, msg.Data)
         }
         instance := registry.NewInput(msg.Type())
         if instance == nil {
@@ -101,7 +101,7 @@ func (p *UnmarshalPipe) Pipe(ctx context.Context, in <-chan *Message) (<-chan *M
 }
 ```
 
-`MarshalPipe` is symmetric: `*Message` in, `*Message` out, and fails with `ErrUnexpectedRawData` if `Data` is *already* `[]byte` instead of silently passing it through — a message reaching `MarshalPipe` already raw is a wiring bug (something upstream marshaled it, or the wrong channel feeds this stage), not a legitimate shortcut. Behavior (unmarshal/marshal semantics, error handling, logging) is otherwise preserved from today — what changes is the channel type (`<-chan *RawMessage` → `<-chan *Message`), the new fail-loud checks, and, as a result, the middleware type they accept: both pipes can now use the same `message.Middleware` type `Router` uses, instead of needing generic `pipe/middleware.Middleware[In, Out]` at all. **This is a breaking change to these two pipes' public signatures** (not just their behavior, now — the fail-loud checks are new/stricter behavior too) — it's the one deliberate break this plan makes to production-used API, done once, up front, so everything downstream (including opting out of `Router`'s default) speaks the same `*Message` type.
+`MarshalPipe` is symmetric: `*Message` in, `*Message` out, and fails with `ErrDataNotTyped` if `Data` is *already* `[]byte` instead of silently passing it through — a message reaching `MarshalPipe` already raw is a wiring bug (something upstream marshaled it, or the wrong channel feeds this stage), not a legitimate shortcut. Behavior (unmarshal/marshal semantics, error handling, logging) is otherwise preserved from today — what changes is the channel type (`<-chan *RawMessage` → `<-chan *Message`), the new fail-loud checks, and, as a result, the middleware type they accept: both pipes can now use the same `message.Middleware` type `Router` uses, instead of needing generic `pipe/middleware.Middleware[In, Out]` at all. **This is a breaking change to these two pipes' public signatures** (not just their behavior, now — the fail-loud checks are new/stricter behavior too) — it's the one deliberate break this plan makes to production-used API, done once, up front, so everything downstream (including opting out of `Router`'s default) speaks the same `*Message` type.
 
 With this in place, opting out of `Router`'s built-in default (Phase 2 below) is simply: don't rely on it — compose `UnmarshalPipe`/`Router`/`MarshalPipe` explicitly as separate stages instead, same as today's pattern, just uniformly typed.
 
@@ -111,15 +111,15 @@ The built-in conversion is **not** baked directly into `Router.process()`. It's 
 
 ```go
 var (
-    // ErrExpectedRawData is returned when a message reaches a conversion stage
+    // ErrDataNotRaw is returned when a message reaches a conversion stage
     // (default-mode Router, UnmarshalPipe) with Data that isn't raw []byte.
-    ErrExpectedRawData = errors.New("expected raw []byte data")
+    ErrDataNotRaw = errors.New("expected raw []byte data")
 
-    // ErrUnexpectedRawData is returned when handler/next output already holds
+    // ErrDataNotTyped is returned when handler/next output already holds
     // raw []byte Data at a point where marshaling is about to be applied
     // (default-mode Router, MarshalPipe) — marshaling it again would silently
     // double-encode.
-    ErrUnexpectedRawData = errors.New("unexpected raw []byte data, want typed")
+    ErrDataNotTyped = errors.New("unexpected raw []byte data, want typed")
 )
 
 // MarshalMiddleware returns middleware that unmarshals raw Data into a typed
@@ -127,15 +127,15 @@ var (
 // Data returned by next back into raw bytes.
 //
 // This asserts the expected state rather than tolerating either: input must
-// be raw (ErrExpectedRawData otherwise), and output must not already be raw
-// (ErrUnexpectedRawData otherwise) — a mismatch means something upstream
+// be raw (ErrDataNotRaw otherwise), and output must not already be raw
+// (ErrDataNotTyped otherwise) — a mismatch means something upstream
 // already converted the message, or the wrong channel/handler is wired in.
 func MarshalMiddleware(registry InputRegistry, marshaler Marshaler) Middleware {
     return func(next ProcessFunc) ProcessFunc {
         return func(ctx context.Context, msg *Message) ([]*Message, error) {
             raw, ok := msg.Raw()
             if !ok {
-                return nil, fmt.Errorf("%w: got %T", ErrExpectedRawData, msg.Data)
+                return nil, fmt.Errorf("%w: got %T", ErrDataNotRaw, msg.Data)
             }
             instance := registry.NewInput(msg.Type())
             if instance == nil {
@@ -153,7 +153,7 @@ func MarshalMiddleware(registry InputRegistry, marshaler Marshaler) Middleware {
 
             for _, out := range outputs {
                 if _, ok := out.Raw(); ok {
-                    return nil, ErrUnexpectedRawData
+                    return nil, ErrDataNotTyped
                 }
                 data, err := marshaler.Marshal(out.Data)
                 if err != nil {
@@ -310,11 +310,11 @@ Considered alongside the no-op sentinel attempts, to let each direction be confi
 | Generic `Copy[In, Out any]` | Becomes `Copy(msg *Message, data any) *Message`. |
 | `ADR 0010` (Dual Message Types) | Needs a new ADR marking it Superseded. |
 | `ParseRaw`/`parseRawBytes` | Return `*Message` with `Data []byte` instead of `*RawMessage`. Public API change. |
-| `message/pipes.go` (`UnmarshalPipe`/`MarshalPipe`) | **Kept, ported first.** Signature changes from `*RawMessage`↔`*Message` to uniform `*Message`→`*Message`, plus new fail-loud checks (behavior is *not* fully preserved — see `ErrExpectedRawData`/`ErrUnexpectedRawData` row below). This is the first implementation step, ahead of `Router`'s own inline behavior, and becomes the supported way to opt out of `Router`'s default. |
+| `message/pipes.go` (`UnmarshalPipe`/`MarshalPipe`) | **Kept, ported first.** Signature changes from `*RawMessage`↔`*Message` to uniform `*Message`→`*Message`, plus new fail-loud checks (behavior is *not* fully preserved — see `ErrDataNotRaw`/`ErrDataNotTyped` row below). This is the first implementation step, ahead of `Router`'s own inline behavior, and becomes the supported way to opt out of `Router`'s default. |
 | `Handler` interface | Unchanged. |
 | `InputRegistry` / `Router.NewInput()` | Unchanged — still how `MarshalMiddleware` gets an instance to unmarshal into. |
-| Error handling | Unmarshal/marshal errors flow through the same auto-nack + `ErrorHandler` path as today. New sentinel errors (`ErrExpectedRawData`, `ErrUnexpectedRawData`) are added, but the path they flow through is unchanged. |
-| `ErrExpectedRawData` / `ErrUnexpectedRawData` (new) | Default-mode `Router` (`MarshalMiddleware`) and `UnmarshalPipe`/`MarshalPipe` now fail loudly instead of silently accepting whatever state `Data` is in: input must be raw, output-to-marshal must not already be raw. Closes a real bug in the untested prior sketch — `MarshalMiddleware` never checked `Raw()` on output at all, so a handler returning `[]byte` directly would have been silently base64-encoded by `JSONMarshaler`. Also removes the implicit "mix raw and typed messages on one channel" pattern `Engine` used to support (see Final Design §3). |
+| Error handling | Unmarshal/marshal errors flow through the same auto-nack + `ErrorHandler` path as today. New sentinel errors (`ErrDataNotRaw`, `ErrDataNotTyped`) are added, but the path they flow through is unchanged. |
+| `ErrDataNotRaw` / `ErrDataNotTyped` (new) | Default-mode `Router` (`MarshalMiddleware`) and `UnmarshalPipe`/`MarshalPipe` now fail loudly instead of silently accepting whatever state `Data` is in: input must be raw, output-to-marshal must not already be raw. Closes a real bug in the untested prior sketch — `MarshalMiddleware` never checked `Raw()` on output at all, so a handler returning `[]byte` directly would have been silently base64-encoded by `JSONMarshaler`. Also removes the implicit "mix raw and typed messages on one channel" pattern `Engine` used to support (see Final Design §3). |
 | `Router` error logging (independent bug, [#151](https://github.com/fxsml/gopipe/issues/151)) | `process()`'s three inline `Logger.Error` calls are removed; logging moves to the `pipe.Config.ErrorHandler` closure in `Router.Pipe()`, the actual boundary that sees every error (middleware + `MarshalMiddleware` + `process()`). Fixes a pre-existing gap — `Use()`-middleware errors were previously silent by default. Filed and fixable independently of this plan, but a practical prerequisite for the new errors above to be observable (see Final Design §6). |
 | `DisableMarshaler` mode | No new checks added here — `Router` doesn't inspect `Data` at all in this mode by design. Mis-shaped `Data` reaching a `commandHandler`-based handler is already caught by the existing `ErrCommandDataMismatch` (fixes #145, already on `develop`); `NewHandler`-based handlers remain the caller's own responsibility, consistent with "Handler is self-describing." |
 | `message/jsonschema` middleware | Mechanical retype only (`message.Middleware` / `*message.Message` / `msg.Raw()`). No logic or API shape change — see Final Design §5. |
@@ -343,7 +343,7 @@ Metrics: ns/op, B/op, allocs/op (`testing.B`), plus `DisableMarshaler` on/off co
 - [ ] Implement `Message` struct simplification (drop generic, add `Raw()`)
 
 **Phase 1 — port existing pipes (do this first):**
-- [ ] Add `ErrExpectedRawData`/`ErrUnexpectedRawData` to `message/errors.go`
+- [ ] Add `ErrDataNotRaw`/`ErrDataNotTyped` to `message/errors.go`
 - [ ] Port `UnmarshalPipe`/`MarshalPipe` to `*Message` → `*Message`, failing loudly on mismatch rather than silently passing through (Final Design §2)
 - [ ] Update pipe middleware usage to `message.Middleware`
 - [ ] Update CHANGELOG (breaking change to these two pipes' signatures *and* behavior — new fail-loud checks, not just a retype)

--- a/docs/plans/marshaling-strategy.md
+++ b/docs/plans/marshaling-strategy.md
@@ -1,0 +1,318 @@
+# Plan: Raw-by-Default Message Contract (Router)
+
+**Status:** Proposed (design settled — no implementation yet)
+**Related Issue:** [#125](https://github.com/fxsml/gopipe/issues/125) — Consider unifying Message and RawMessage for middleware composability
+**Related ADRs:** [0010](../adr/0010-dual-message-types.md) (Dual Message Types — to be superseded), [0022](../adr/0022-message-package-redesign.md) (Message Package Redesign)
+**Related Plans:** [archive/0008-marshal-unmarshal-pipes.decisions.md](archive/0008-marshal-unmarshal-pipes.decisions.md), [validation-marshaling-separation.decisions.md](validation-marshaling-separation.decisions.md)
+**Depends On:** [engine-removal.md](engine-removal.md) — must complete before this plan's Phase 1 (dropping `TypedMessage[T]`/`RawMessage` would otherwise break `Engine`'s compile)
+**Tracking Issues:** Phase 1 — [fxsml/gopipe#148](https://github.com/fxsml/gopipe/issues/148); Phase 2 — [fxsml/gopipe#149](https://github.com/fxsml/gopipe/issues/149)
+
+## Overview
+
+**Scope cut:** `Engine` is out of scope for this plan — but not because it's being left alone. It's tracked and removed entirely in its own plan, [engine-removal.md](engine-removal.md) ("Phase 0"), which must land first. `Router`, `Merger`, and `Distributor` survive as independent components and are what this plan actually touches.
+
+The design adopts the proposal from #125 directly rather than a narrower slice of it: `Message` carries `Data any` and is assumed to hold raw bytes by default. A `Raw()` accessor detects whether conversion is needed. `Router` performs unmarshal/marshal inline, in the same worker goroutine that runs the handler, via a public `MarshalMiddleware(registry, marshaler) Middleware` that `Router` installs by default (configured via `Marshaler`, default JSON) and can be disabled with a single `DisableMarshaler` flag when a pipeline wants to build its own path.
+
+**Fail loudly on mismatch, not silently both.** `Raw()` is used to *assert* the expected state, not to silently branch between accepting raw or typed input. Collapsing `Message`/`RawMessage` into one type (per #125) trades a compile-time guarantee (today, `UnmarshalPipe` takes `<-chan *RawMessage` — the compiler forbids feeding it typed data) for a runtime one; the whole point of paying that cost is to enforce it, not to quietly tolerate either state. See §2 and §3.
+
+**Phasing:** `UnmarshalPipe`/`MarshalPipe` are in production use and stay — but they aren't left untouched. They get ported to the new `Message`-only contract (`*Message` in, `*Message` out, converting via `Raw()` internally, same as `Router` will) as the **first** implementation step, ahead of `Router`'s own built-in default behavior. Once ported, they also become the mechanism for opting out of `Router`'s inline default: compose them as explicit stages instead of relying on `Router`'s built-in conversion. `Router`'s built-in inline marshal/unmarshal (below) is a **second, later** phase.
+
+No implementation has started. This document records the research, the design as it evolved through several rejected intermediate options, and the final shape for `Router` and the existing pipes.
+
+## Rebased onto develop
+
+Rebased onto `origin/develop` after ~15 commits landed there since this branch was created; replayed cleanly, no conflicts. Re-checked this plan's design against what changed:
+
+- **`PipeConfig` gained `Metrics`, `Labels`, `LabelFunc`** (pipeline observability, unrelated feature area). Purely additive — coexists on the same struct as this plan's new `Marshaler`/`DisableMarshaler` fields, no conflict.
+- **`Router` gained `Stats()`**, backed by an internal `atomic.Pointer[pipe.ProcessPipe[...]]` set in `Pipe()`. `UnmarshalPipe`/`MarshalPipe` gained the same `Stats()` plus Metrics/Labels wiring. Phase 1's pipe port and Phase 2's `Router` changes need to preserve this — additive, not a redesign.
+- **`commandHandler.Handle()` now returns `ErrCommandDataMismatch`** instead of silently zero-valuing when `msg.Data` doesn't type-assert to `*C`/`C` (fixes #145). This reinforces this plan rather than conflicting with it: `MarshalMiddleware`'s unmarshal path already produces exactly `*C` via `registry.NewInput()`, so it's unaffected there; and for `DisableMarshaler: true` pipelines, a caller handing `Router` mistyped `Data` now gets a clear error instead of silent corruption — a net improvement for this plan's opt-out path.
+- **`message/http` gained `SubscriberConfig.ErrorHandler`** for nack response handling (#140). Doesn't touch `*RawMessage`'s type signature — still out of this plan's scope.
+- **New `message/otel` subpackage** — wraps `pipe.Metrics`/`Stats()` only, no coupling to `Message`/`RawMessage`. Unaffected.
+
+No conflicts. The design below stands as-is against current `develop`.
+
+## Current State (Research)
+
+### Issue and repo survey
+
+- Issue [#125](https://github.com/fxsml/gopipe/issues/125) is open, unassigned, no linked PRs or comments. It proposes collapsing `*Message`/`*RawMessage` into one type (`Data any`, plus a `Raw() ([]byte, bool)` helper) so `Middleware[*Message, *Message]` works everywhere instead of four incompatible signatures (Proxy, Unmarshal, Marshal, Handler). It explicitly defers a decision pending impact evaluation — nothing was prototyped. This plan now adopts that proposal directly (see Final Design).
+- No other open branch or PR touches marshal/unmarshal architecture.
+
+### Prior art already in the repo
+
+- **ADR 0010** (Dual Message Types) — `Message = TypedMessage[any]`, `RawMessage = TypedMessage[[]byte]` via type alias; zero runtime cost, same underlying struct. Superseded by this plan (see Consequences).
+- **ADR 0022** (Message Package Redesign) — deliberately separated `Marshaler` (pure serialization) from `Handler` (self-describing, creates typed instances via `NewInput()`), and from `Router`/`Engine` orchestration. That separation is preserved — `Marshaler` stays a pure serialization interface; `Router` just calls it inline instead of via a dedicated pipe.
+- **`archive/0008-marshal-unmarshal-pipes.decisions.md`** — design history for `UnmarshalPipe`/`MarshalPipe` as standalone public pipes, justified for reuse *outside* Engine. These are in production use today; this plan keeps and ports them rather than dropping them (see Final Design and Consequences).
+- **`validation-marshaling-separation.decisions.md`** — resolved in favor of pure separation: `jsonschema.Registry` + middleware validates raw bytes without requiring Go types, independent of the `Marshaler`. Untouched by this plan — that middleware operates purely on bytes and never needs `Router` involved.
+
+### Current marshal/unmarshal topology (being replaced, Router path only)
+
+`Router` today assumes its input channel already carries typed `*Message` — conversion from `*RawMessage` happens upstream via a dedicated `UnmarshalPipe`, and conversion back happens downstream via a dedicated `MarshalPipe` (see `message/pipes.go`), each with its own worker pool and buffered channel. This plan removes the need for a *separate pipe stage* to do that conversion — `Router` does it inline by default. It does not mean `Router` tolerates a mix of raw and typed messages on the same channel: in default mode every message is expected raw, full stop (see "Fail loudly," above, and §3).
+
+## Final Design
+
+### 1. `Message` becomes a concrete struct — `TypedMessage[T]` is dropped
+
+```go
+type Message struct {
+    Data       any
+    Attributes Attributes
+    acking     *Acking
+    locals     map[any]any
+}
+
+// Raw reports whether Data currently holds raw bytes, and returns them.
+func (m *Message) Raw() ([]byte, bool) {
+    b, ok := m.Data.([]byte)
+    return b, ok
+}
+```
+
+No generic parameter, no `RawMessage` alias, no `NewTyped[T]`. `New(data any, attrs, acking)` is the only constructor. `Copy(msg *Message, data any) *Message` loses its generic type parameters. This is a deliberate, larger scope cut than initially planned — it gives up the "compile-time-typed pipeline" use case ADR 0010 introduced `TypedMessage[T]` for for the sake of one simple, uniform type.
+
+### 2. `UnmarshalPipe`/`MarshalPipe` port to `*Message` → `*Message` (Phase 1, implemented first)
+
+These stay as public pipes — they're in production — but their signature changes from `pipe.ProcessPipe[*RawMessage, *Message]` / `pipe.ProcessPipe[*Message, *RawMessage]` to a single uniform `pipe.ProcessPipe[*Message, *Message]`, using `Raw()` internally exactly like `Router` will:
+
+```go
+func NewUnmarshalPipe(registry InputRegistry, marshaler Marshaler, cfg PipeConfig) *UnmarshalPipe {
+    p := &UnmarshalPipe{}
+    p.inner = pipe.NewProcessPipe(func(ctx context.Context, msg *Message) ([]*Message, error) {
+        raw, ok := msg.Raw()
+        if !ok {
+            return nil, fmt.Errorf("%w: got %T", ErrExpectedRawData, msg.Data)
+        }
+        instance := registry.NewInput(msg.Type())
+        if instance == nil {
+            return nil, ErrUnknownType
+        }
+        if err := marshaler.Unmarshal(raw, instance); err != nil {
+            return nil, err
+        }
+        msg.Data = instance
+        return []*Message{msg}, nil
+    }, ...)
+    return p
+}
+
+func (p *UnmarshalPipe) Pipe(ctx context.Context, in <-chan *Message) (<-chan *Message, error) {
+    return p.inner.Pipe(ctx, in)
+}
+```
+
+`MarshalPipe` is symmetric: `*Message` in, `*Message` out, and fails with `ErrUnexpectedRawData` if `Data` is *already* `[]byte` instead of silently passing it through — a message reaching `MarshalPipe` already raw is a wiring bug (something upstream marshaled it, or the wrong channel feeds this stage), not a legitimate shortcut. Behavior (unmarshal/marshal semantics, error handling, logging) is otherwise preserved from today — what changes is the channel type (`<-chan *RawMessage` → `<-chan *Message`), the new fail-loud checks, and, as a result, the middleware type they accept: both pipes can now use the same `message.Middleware` type `Router` uses, instead of needing generic `pipe/middleware.Middleware[In, Out]` at all. **This is a breaking change to these two pipes' public signatures** (not just their behavior, now — the fail-loud checks are new/stricter behavior too) — it's the one deliberate break this plan makes to production-used API, done once, up front, so everything downstream (including opting out of `Router`'s default) speaks the same `*Message` type.
+
+With this in place, opting out of `Router`'s built-in default (Phase 2 below) is simply: don't rely on it — compose `UnmarshalPipe`/`Router`/`MarshalPipe` explicitly as separate stages instead, same as today's pattern, just uniformly typed.
+
+### 3. `Router`: marshal/unmarshal as a public, swappable `Middleware` (Phase 2, later)
+
+The built-in conversion is **not** baked directly into `Router.process()`. It's an ordinary, public `Middleware` — `Router` just happens to install it by default. This is what makes it swappable instead of merely togglable (see §5, needed for `jsonschema`):
+
+```go
+var (
+    // ErrExpectedRawData is returned when a message reaches a conversion stage
+    // (default-mode Router, UnmarshalPipe) with Data that isn't raw []byte.
+    ErrExpectedRawData = errors.New("expected raw []byte data")
+
+    // ErrUnexpectedRawData is returned when handler/next output already holds
+    // raw []byte Data at a point where marshaling is about to be applied
+    // (default-mode Router, MarshalPipe) — marshaling it again would silently
+    // double-encode.
+    ErrUnexpectedRawData = errors.New("unexpected raw []byte data, want typed")
+)
+
+// MarshalMiddleware returns middleware that unmarshals raw Data into a typed
+// instance (via registry.NewInput) before calling next, and marshals typed
+// Data returned by next back into raw bytes.
+//
+// This asserts the expected state rather than tolerating either: input must
+// be raw (ErrExpectedRawData otherwise), and output must not already be raw
+// (ErrUnexpectedRawData otherwise) — a mismatch means something upstream
+// already converted the message, or the wrong channel/handler is wired in.
+func MarshalMiddleware(registry InputRegistry, marshaler Marshaler) Middleware {
+    return func(next ProcessFunc) ProcessFunc {
+        return func(ctx context.Context, msg *Message) ([]*Message, error) {
+            raw, ok := msg.Raw()
+            if !ok {
+                return nil, fmt.Errorf("%w: got %T", ErrExpectedRawData, msg.Data)
+            }
+            instance := registry.NewInput(msg.Type())
+            if instance == nil {
+                return nil, ErrUnknownType
+            }
+            if err := marshaler.Unmarshal(raw, instance); err != nil {
+                return nil, fmt.Errorf("unmarshal: %w", err)
+            }
+            msg.Data = instance
+
+            outputs, err := next(ctx, msg)
+            if err != nil {
+                return nil, err
+            }
+
+            for _, out := range outputs {
+                if _, ok := out.Raw(); ok {
+                    return nil, ErrUnexpectedRawData
+                }
+                data, err := marshaler.Marshal(out.Data)
+                if err != nil {
+                    return nil, fmt.Errorf("marshal: %w", err)
+                }
+                out.Data = data
+                if out.Attributes == nil {
+                    out.Attributes = make(Attributes)
+                }
+                out.Attributes[AttrDataContentType] = marshaler.DataContentType()
+            }
+            return outputs, nil
+        }
+    }
+}
+```
+
+This closes a real gap the earlier sketch had: it only checked `Raw()` on the *input* side, and unconditionally called `marshaler.Marshal(out.Data)` on output with no check at all. A handler returning `[]byte` as its event type directly (`NewCommandHandler[Cmd, []byte]` is valid Go) would have silently base64-encoded already-raw output via `JSONMarshaler` — a real double-encoding bug, not just a hypothetical. The output-side `Raw()` check fixes that at the same time as adding the loud-failure behavior.
+
+```go
+type PipeConfig struct {
+    ...
+    Marshaler        Marshaler // default: NewJSONMarshaler() — single combined interface, unchanged from today
+    DisableMarshaler bool      // when true, Router installs no built-in conversion middleware — build the path yourself via Use()
+}
+```
+
+`r.process()` goes back to being simple — handler lookup, matcher check, `Handle()` — no conversion logic at all, always assumes typed `Data`:
+
+```go
+func (r *Router) process(ctx context.Context, msg *Message) ([]*Message, error) {
+    entry, ok := r.handler(msg.Type())
+    if !ok {
+        return nil, ErrNoHandler
+    }
+    if entry.matcher != nil && !entry.matcher.Match(msg.Attributes) {
+        return nil, ErrHandlerRejected
+    }
+    return entry.handler.Handle(msg.Context(ctx), msg)
+}
+```
+
+`Router.Pipe()` installs `MarshalMiddleware(r, r.cfg.Marshaler)` — `r` itself as the `InputRegistry`, unchanged — as the innermost wrapper, unless `DisableMarshaler` is set:
+
+```go
+fn := r.process
+if !r.cfg.DisableMarshaler {
+    fn = MarshalMiddleware(r, r.cfg.Marshaler)(fn)
+}
+for i := len(r.middleware) - 1; i >= 0; i-- {
+    fn = r.middleware[i](fn)
+}
+fn = r.ackingMiddleware()(fn)
+```
+
+One switch covers both directions symmetrically: `DisableMarshaler` means "`Router` never touches `Data`, at all" — not an asymmetric per-direction gate. Anyone needing the built-in behavior but with different validation/ordering semantics (see §5) sets `DisableMarshaler: true` and registers their own middleware, built from the same `Marshaler` primitive, via `Use()`.
+
+The `DisableMarshaler` field's godoc should state the general rule, not just point at `Subject()` as a one-off case: *any* `Use()` middleware that reads or sets `msg.Data`/`out.Data` expecting a concrete Go type — not `Attributes` — needs `DisableMarshaler: true`, because `Use()` middleware always runs outside the built-in conversion (pre-unmarshal input, post-marshal output; see §5). `Subject()` is documented as the one existing example, cross-referenced from both sides, so the constraint is discoverable from `Router`'s docs by anyone writing new middleware, not only by someone already suspicious of `Subject()`.
+
+**Consequence of fail-loud: no implicit mixed raw/typed sources.** `DisableMarshaler` is a per-`Router`-instance, not per-message, switch — there is no longer a way for one `Router` to silently accept some messages raw and others already typed on the same channel. Today's `Engine` (being removed regardless — see [engine-removal.md](engine-removal.md)) supported exactly that: `AddInput` (typed) and `AddRawInput` (raw, via `UnmarshalPipe`) fed the same shared `Merger`, which fed one `Router`. Reproducing that pattern now requires explicit composition: unmarshal the raw sources first (via the ported `UnmarshalPipe`), merge everything as uniformly typed (via `Merger`, which survives — see engine-removal.md), and feed a `DisableMarshaler: true` `Router`. This is a deliberate constraint, not an oversight: it's what makes the fail-loud behavior meaningful instead of best-effort.
+
+### 4. Middleware signature collapses to one
+
+Today: `Middleware[*RawMessage,*Message]` (unmarshal), `Middleware[*Message,*RawMessage]` (marshal), `Middleware[*Message,*Message]` (handlers), `Middleware[*RawMessage,*RawMessage]` (proxy) — four incompatible instantiations, per #125. After: everything is `message.Middleware = func(ProcessFunc) ProcessFunc` over `*Message` — the type `Router` already uses, and the type `MarshalMiddleware` itself returns. Validation, correlation-ID, deadline, and any future middleware compose via the same `Use()`, regardless of whether the message happens to be raw or typed at the point they run — though *which* it is at that point is not arbitrary; see §5.
+
+### 5. Provided middleware — impact analysis
+
+Collapsing to one middleware type doesn't mean every existing middleware is unaffected — whether a message is raw or typed at the point a given `Use()` middleware runs depends on where the built-in `MarshalMiddleware` sits (innermost, per §3): **`Use()` middleware always sees pre-unmarshal input and post-marshal output**, because the built-in conversion is nested *inside* the `Use()` chain, not outside it.
+
+**`message/jsonschema`** (`NewValidationMiddleware`, `NewInputValidationMiddleware`, `NewOutputValidationMiddleware`) — this positioning is exactly what they need: input validation wants raw bytes *before* unmarshal, output validation wants raw bytes *after* marshal. Both naturally line up with `Use()`'s vantage point. **Scope kept minimal, as instructed** — no redesign, no collapsing into one middleware, no `Registry` changes. The only change is mechanical: retype from `middleware.Middleware[*message.RawMessage, ...]` (generic `pipe/middleware`) to `message.Middleware` over `*message.Message`, and swap direct `.Data` access for `msg.Raw()`. Same three functions, same call sites, same behavior.
+
+**`message/middleware`** — checked all five, re-verified by grep for `.Data` across the actual middleware source (not just re-reading):
+- `CorrelationID()`, `Deadline()`, `Recover()`, `ValidateRequired()` — **zero** `.Data` references in any of the four files. They operate only on `Attributes` (or nothing at all, for `Recover()`). **Unaffected**, raw or typed makes no difference.
+- **`Subject()` — the single exception, and it breaks silently under `Router`'s default (marshal-enabled) mode.** It does `if s, ok := out.Data.(subjecter); ok { ... }` on `next()`'s output — a duck-typed check that only succeeds if `Data` is still a concrete Go type. But by the time `next()` returns to a `Use()`-registered middleware, the built-in `MarshalMiddleware` (nested inside) has already marshaled `out.Data` to `[]byte`. The type assertion always fails, `AttrSubject` never gets set — no error, just a silent no-op. This is a real regression, not a rename.
+
+So the finding is a single root cause with a single concrete instance today (`Subject()`), not a pattern spread across several middleware — but the constraint it exposes is general (any middleware reading/setting typed `Data`), so it's documented in two places: a specific note on `Subject()`'s godoc, and the general rule on `Router`'s `DisableMarshaler` godoc (§3) so it's discoverable independent of already knowing about `Subject()`.
+
+**Root cause:** `jsonschema`'s middleware and `Subject()` want opposite things at the same seam. `jsonschema` wants to sit *outside* the conversion boundary (raw in, raw out) — satisfied by the innermost built-in positioning. `Subject()` wants to sit *inside* it (typed only, between `Handle()` and marshal) — which no position of a single combined `Use()`-relative built-in middleware can satisfy simultaneously with `jsonschema`'s requirement. There is no single placement that serves both.
+
+**Resolution — no new API, per "don't scope creep":** `Subject()` requires `DisableMarshaler: true`. On a `Router` with the built-in conversion disabled, `Data` stays typed all the way through `Use()` middleware (in and out), so `Subject()` works exactly as it does today — marshaling, if needed, happens downstream as an explicit step (e.g. the ported `MarshalPipe` from §2, composed after `Router`), which recreates the seam `Subject()` needs via explicit pipe composition instead of implicit middleware ordering. This needs a godoc update in **two places**, not one: `Subject()` itself, and `Router`'s `DisableMarshaler` field (§3) stating the general rule so future middleware authors find it without already knowing `Subject()` is affected. No Router redesign, no second middleware hook.
+
+## Design Evolution — Rejected Intermediate Options
+
+Recorded here because they were seriously considered before landing on the Final Design above.
+
+### Rejected: marshal/unmarshal as `Engine`-installed middleware, `RawMessage` kept as a distinct type
+
+Earlier direction: keep the `TypedMessage[T]` dual-type system, keep `RawMessage`, and make `Engine` install unmarshal/marshal as ordinary `Middleware[*Message,*Message]` around `Router`'s existing worker, converting `*RawMessage` → `*Message` at ingress as a free struct copy. This was a narrower, lower-risk slice of #125.
+
+**Why rejected:** `Engine` was cut from v1 scope entirely, which removed the motivating use case (Engine's per-input/output dedicated pipe stages and their shutdown-cascade complexity). Once `Router` is the only thing in scope, there's no reason to route the conversion through a middleware layer instead of building it directly into `Router.process()` — and no reason to keep two type instantiations (`Message`/`RawMessage`) of the same struct when the boundary check (`Raw()`) already tells you everything you need to know.
+
+### Rejected: `NoOpUnmarshaler`/`NoOpMarshaler` that copy into `*[]byte`
+
+First opt-out attempt: split `Marshaler` into `Unmarshaler`/`Marshaler` interfaces, and provide no-op implementations that still did work — `NoOpUnmarshaler.Unmarshal` type-asserted the target to `*[]byte` and copied raw bytes into it, requiring `Handler.NewInput()` to return `*[]byte` for opted-out handlers.
+
+**Why rejected:** This wasn't actually "opting out" — it still required every handler using it to be specially shaped, and it conflated "skip conversion" with "convert into a specific alternate shape." The real requirement was simpler: when typed data is wanted, do *literally nothing* to `Data`.
+
+### Rejected: `NoOpUnmarshaler`/`NoOpMarshaler` as pure sentinel types
+
+Second attempt: keep the no-op types, but make their methods true no-ops (`return nil`), and have `Router` type-switch on the configured `Marshaler`/`Unmarshaler` to skip the conversion block entirely when a no-op sentinel is configured.
+
+**Why rejected:** The dead method bodies were a footgun — if the sentinel type were ever called directly (e.g., someone using it standalone), it would silently misbehave rather than error. It also required two new exported types and a split interface for something that, on inspection, decomposes into one gate that already exists for free (`Raw()`, for unmarshal) and one gate that doesn't need a whole type to express (a bool, for marshal).
+
+### Rejected: splitting `Marshaler` into `Unmarshaler`/`Marshaler` interfaces
+
+Considered alongside the no-op sentinel attempts, to let each direction be configured independently.
+
+**Why rejected:** Once the no-op sentinels were dropped in favor of `Raw()` (structural, for unmarshal) + `DisableMarshaling bool` (explicit, for marshal), there was no remaining requirement driving the split — no concrete use case for plugging in different implementations per direction. Keeping the single combined `Marshaler` interface (unchanged from today) is less API surface for the same behavior.
+
+## Consequences / Ripple Effects
+
+| Area | Impact |
+|---|---|
+| `TypedMessage[T]`, `RawMessage`, `NewTyped[T]`, `NewRaw` | Removed. `Message` is a concrete struct; `New(data any, attrs, acking)` is the only constructor. |
+| Generic `Copy[In, Out any]` | Becomes `Copy(msg *Message, data any) *Message`. |
+| `ADR 0010` (Dual Message Types) | Needs a new ADR marking it Superseded. |
+| `ParseRaw`/`parseRawBytes` | Return `*Message` with `Data []byte` instead of `*RawMessage`. Public API change. |
+| `message/pipes.go` (`UnmarshalPipe`/`MarshalPipe`) | **Kept, ported first.** Signature changes from `*RawMessage`↔`*Message` to uniform `*Message`→`*Message`, plus new fail-loud checks (behavior is *not* fully preserved — see `ErrExpectedRawData`/`ErrUnexpectedRawData` row below). This is the first implementation step, ahead of `Router`'s own inline behavior, and becomes the supported way to opt out of `Router`'s default. |
+| `Handler` interface | Unchanged. |
+| `InputRegistry` / `Router.NewInput()` | Unchanged — still how `MarshalMiddleware` gets an instance to unmarshal into. |
+| Error handling | Unmarshal/marshal errors flow through the same auto-nack + `ErrorHandler` path as today. New sentinel errors (`ErrExpectedRawData`, `ErrUnexpectedRawData`) are added, but the path they flow through is unchanged. |
+| `ErrExpectedRawData` / `ErrUnexpectedRawData` (new) | Default-mode `Router` (`MarshalMiddleware`) and `UnmarshalPipe`/`MarshalPipe` now fail loudly instead of silently accepting whatever state `Data` is in: input must be raw, output-to-marshal must not already be raw. Closes a real bug in the untested prior sketch — `MarshalMiddleware` never checked `Raw()` on output at all, so a handler returning `[]byte` directly would have been silently base64-encoded by `JSONMarshaler`. Also removes the implicit "mix raw and typed messages on one channel" pattern `Engine` used to support (see Final Design §3). |
+| `DisableMarshaler` mode | No new checks added here — `Router` doesn't inspect `Data` at all in this mode by design. Mis-shaped `Data` reaching a `commandHandler`-based handler is already caught by the existing `ErrCommandDataMismatch` (fixes #145, already on `develop`); `NewHandler`-based handlers remain the caller's own responsibility, consistent with "Handler is self-describing." |
+| `message/jsonschema` middleware | Mechanical retype only (`message.Middleware` / `*message.Message` / `msg.Raw()`). No logic or API shape change — see Final Design §5. |
+| `message/middleware.Subject()` | **Breaking behavior change.** Silently stops setting `AttrSubject` when used on a `Router` with the default (marshal-enabled) `MarshalMiddleware` installed. Requires `DisableMarshaler: true` going forward. Needs a godoc update on `Subject()` *and* on `Router.DisableMarshaler` (general rule, not a `Subject()`-specific caveat). |
+| `message/middleware` (`CorrelationID`, `Deadline`, `Recover`, `ValidateRequired`) | Unaffected — `Attributes`-only, never touch `Data`. |
+
+## Open Questions
+
+1. ~~Keep `UnmarshalPipe`/`MarshalPipe` at all for v1?~~ **Resolved: keep both, port them to `*Message`→`*Message` as Phase 1** (see Final Design §2). They stay as production API and become the supported opt-out path for `Router`'s Phase 2 default behavior.
+2. **`DataContentType` validation on unmarshal** — should `Router` check the incoming `datacontenttype` attribute against the configured `Marshaler` before unmarshaling, or stay silent like today? Proposed: stay silent for v1, no new behavior.
+3. **ADR required.** This changes an architectural pattern and removes a public type (`TypedMessage[T]`/`RawMessage`) per `docs/procedures/adr.md`. An ADR superseding ADR 0010 is needed before implementation — it should cover both phases (pipes port + Router default) since they share the same underlying `Message` contract change.
+
+## Benchmark Plan
+
+The original motivation for benchmarking — comparing Engine's dedicated-pool pipe stages against an inline alternative — no longer applies now that Engine is out of scope; there is no competing "before" implementation to compare against. What remains useful is characterizing `Router`'s own inline marshal/unmarshal cost before merging, using the same scenario shapes considered earlier:
+
+1. **Small payload, high volume, negligible handler cost** — baseline per-message overhead of the inline unmarshal/marshal calls.
+2. **Large/nested payload (few KB), cheap handler** — CPU-bound marshal cost sharing the router's worker pool with handler execution; run at multiple `Concurrency` settings to see whether marshal cost becomes a bottleneck at low concurrency.
+3. **Realistic I/O-bound handler (simulated latency, e.g. 100µs–1ms sleep), moderate concurrency** — confirms marshal cost hides behind I/O wait in the common case.
+
+Metrics: ns/op, B/op, allocs/op (`testing.B`), plus `DisableMarshaler` on/off comparison to quantify the marshal step's own cost in isolation.
+
+## Next Steps
+
+- [ ] Write ADR superseding ADR 0010 (drop `TypedMessage[T]`/`RawMessage`, adopt raw-by-default `Message` contract; covers both phases)
+- [ ] Implement `Message` struct simplification (drop generic, add `Raw()`)
+
+**Phase 1 — port existing pipes (do this first):**
+- [ ] Add `ErrExpectedRawData`/`ErrUnexpectedRawData` to `message/errors.go`
+- [ ] Port `UnmarshalPipe`/`MarshalPipe` to `*Message` → `*Message`, failing loudly on mismatch rather than silently passing through (Final Design §2)
+- [ ] Update pipe middleware usage to `message.Middleware`
+- [ ] Update CHANGELOG (breaking change to these two pipes' signatures *and* behavior — new fail-loud checks, not just a retype)
+
+**Phase 2 — Router built-in default (later):**
+- [ ] Implement public `MarshalMiddleware(registry, marshaler) Middleware` with fail-loud input/output checks (Final Design §3)
+- [ ] Implement `Router` changes (`Marshaler`/`DisableMarshaler` config, install `MarshalMiddleware` by default, simplify `process()`)
+- [ ] Retype `message/jsonschema`'s three middleware constructors (mechanical only — Final Design §5)
+- [ ] Update `Subject()` godoc to document the `DisableMarshaler: true` requirement (Final Design §5)
+- [ ] Update `Router.DisableMarshaler` field godoc with the general rule (any middleware reading/setting typed `Data` needs it), cross-referenced with `Subject()` — not discoverable only via `Subject()`'s docs (Final Design §3, §5)
+- [ ] Add benchmarks (scenarios above)
+- [ ] Update CHANGELOG (note `Subject()` behavior change and the fail-loud mismatch errors explicitly, not just as a signature change)
+- [ ] Update this plan's status to Complete

--- a/docs/plans/marshaling-strategy.md
+++ b/docs/plans/marshaling-strategy.md
@@ -6,6 +6,7 @@
 **Related Plans:** [archive/0008-marshal-unmarshal-pipes.decisions.md](archive/0008-marshal-unmarshal-pipes.decisions.md), [validation-marshaling-separation.decisions.md](validation-marshaling-separation.decisions.md)
 **Depends On:** [engine-removal.md](engine-removal.md) — must complete before this plan's Phase 1 (dropping `TypedMessage[T]`/`RawMessage` would otherwise break `Engine`'s compile)
 **Tracking Issues:** Phase 1 — [fxsml/gopipe#148](https://github.com/fxsml/gopipe/issues/148); Phase 2 — [fxsml/gopipe#149](https://github.com/fxsml/gopipe/issues/149)
+**Related Bug (independent, not part of this plan):** [fxsml/gopipe#151](https://github.com/fxsml/gopipe/issues/151) — `Router` errors from `Use()` middleware are silently swallowed; see Final Design §6
 
 ## Overview
 
@@ -234,6 +235,45 @@ So the finding is a single root cause with a single concrete instance today (`Su
 
 **Resolution — no new API, per "don't scope creep":** `Subject()` requires `DisableMarshaler: true`. On a `Router` with the built-in conversion disabled, `Data` stays typed all the way through `Use()` middleware (in and out), so `Subject()` works exactly as it does today — marshaling, if needed, happens downstream as an explicit step (e.g. the ported `MarshalPipe` from §2, composed after `Router`), which recreates the seam `Subject()` needs via explicit pipe composition instead of implicit middleware ordering. This needs a godoc update in **two places**, not one: `Subject()` itself, and `Router`'s `DisableMarshaler` field (§3) stating the general rule so future middleware authors find it without already knowing `Subject()` is affected. No Router redesign, no second middleware hook.
 
+### 6. Error logging: move to the real boundary, not just add more inline calls
+
+While reviewing where `MarshalMiddleware`'s new `ErrDataNotRaw`/`ErrDataNotTyped` errors should be logged, a pre-existing gap surfaced in `Router` itself — **tracked as its own bug, independent of this plan: [fxsml/gopipe#151](https://github.com/fxsml/gopipe/issues/151).** Not fixing it here would mean the new errors inherit the same gap.
+
+The gap: `pipe.Config.ErrorHandler`'s own godoc says "Default logs via slog.Error" — the `pipe` package would log every error centrally if left alone. But `Router.Pipe()` overrides it:
+
+```go
+ErrorHandler: func(in any, err error) {
+    msg := in.(*Message)
+    msg.Nack(err)
+    r.cfg.ErrorHandler(msg, err) // defaults to a no-op
+},
+```
+
+This suppresses the pipe package's default logging and replaces it with Nack-only. Meanwhile `process()` separately hand-rolls logging, but only inline at its own three failure sites (`ErrNoHandler`, `ErrHandlerRejected`, handler execution failure). Any error returned by a `Use()`-registered middleware (`ValidateRequired`, `Deadline`, `jsonschema`'s validation middleware, `Subject()`) never reaches `process()` at all — middleware short-circuits before calling `next()` — so it hits the overridden `ErrorHandler`, which doesn't log. **By default, those errors are completely silent today:** Nacked, no log line, unless the caller supplies their own `ErrorHandler` that happens to log.
+
+**Decision for this plan:** rather than adding a fourth inline `Logger.Error` call inside `MarshalMiddleware` (which would still leave the underlying gap in place for every other middleware), move logging to the actual boundary — the `pipe.Config.ErrorHandler` closure in `Router.Pipe()`, which structurally sees every error from the whole chain (middleware, `MarshalMiddleware`, and `process()` alike) exactly once:
+
+```go
+cfg := pipe.Config{
+    ...
+    ErrorHandler: func(in any, err error) {
+        msg := in.(*Message)
+        msg.Nack(err)
+        r.cfg.Logger.Error("Processing failed",
+            "component", "router",
+            "error", err,
+            "attributes", msg.Attributes)
+        r.cfg.ErrorHandler(msg, err)
+    },
+}
+```
+
+`process()`'s three inline `Logger.Error` calls come out entirely — it just returns errors. `MarshalMiddleware` needs no `Logger` dependency of its own; its errors are covered by this same central point, for free, keeping it minimal.
+
+**Trade-off:** loses the differentiated message text per failure site ("Routing message failed" vs. "Matching handler failed" vs. "Executing handler failed") in favor of one generic line — though the sentinel errors' own text (`"no handler for message type"`, `"message rejected by handler matcher"`) is descriptive enough to grep on. Since `Router` is in production, if anyone's alerting matches the old specific outer message strings rather than the error text, that's a real behavior change worth calling out in the CHANGELOG, not just folding in silently.
+
+This fix is filed and land-able independently of this plan (it's a `Router` bug today, with or without the marshaling redesign) but is a prerequisite in practice for §3's new errors to be observable by default — sequence it alongside or before Phase 2.
+
 ## Design Evolution — Rejected Intermediate Options
 
 Recorded here because they were seriously considered before landing on the Final Design above.
@@ -275,6 +315,7 @@ Considered alongside the no-op sentinel attempts, to let each direction be confi
 | `InputRegistry` / `Router.NewInput()` | Unchanged — still how `MarshalMiddleware` gets an instance to unmarshal into. |
 | Error handling | Unmarshal/marshal errors flow through the same auto-nack + `ErrorHandler` path as today. New sentinel errors (`ErrExpectedRawData`, `ErrUnexpectedRawData`) are added, but the path they flow through is unchanged. |
 | `ErrExpectedRawData` / `ErrUnexpectedRawData` (new) | Default-mode `Router` (`MarshalMiddleware`) and `UnmarshalPipe`/`MarshalPipe` now fail loudly instead of silently accepting whatever state `Data` is in: input must be raw, output-to-marshal must not already be raw. Closes a real bug in the untested prior sketch — `MarshalMiddleware` never checked `Raw()` on output at all, so a handler returning `[]byte` directly would have been silently base64-encoded by `JSONMarshaler`. Also removes the implicit "mix raw and typed messages on one channel" pattern `Engine` used to support (see Final Design §3). |
+| `Router` error logging (independent bug, [#151](https://github.com/fxsml/gopipe/issues/151)) | `process()`'s three inline `Logger.Error` calls are removed; logging moves to the `pipe.Config.ErrorHandler` closure in `Router.Pipe()`, the actual boundary that sees every error (middleware + `MarshalMiddleware` + `process()`). Fixes a pre-existing gap — `Use()`-middleware errors were previously silent by default. Filed and fixable independently of this plan, but a practical prerequisite for the new errors above to be observable (see Final Design §6). |
 | `DisableMarshaler` mode | No new checks added here — `Router` doesn't inspect `Data` at all in this mode by design. Mis-shaped `Data` reaching a `commandHandler`-based handler is already caught by the existing `ErrCommandDataMismatch` (fixes #145, already on `develop`); `NewHandler`-based handlers remain the caller's own responsibility, consistent with "Handler is self-describing." |
 | `message/jsonschema` middleware | Mechanical retype only (`message.Middleware` / `*message.Message` / `msg.Raw()`). No logic or API shape change — see Final Design §5. |
 | `message/middleware.Subject()` | **Breaking behavior change.** Silently stops setting `AttrSubject` when used on a `Router` with the default (marshal-enabled) `MarshalMiddleware` installed. Requires `DisableMarshaler: true` going forward. Needs a godoc update on `Subject()` *and* on `Router.DisableMarshaler` (general rule, not a `Subject()`-specific caveat). |
@@ -308,6 +349,7 @@ Metrics: ns/op, B/op, allocs/op (`testing.B`), plus `DisableMarshaler` on/off co
 - [ ] Update CHANGELOG (breaking change to these two pipes' signatures *and* behavior — new fail-loud checks, not just a retype)
 
 **Phase 2 — Router built-in default (later):**
+- [ ] Fix [#151](https://github.com/fxsml/gopipe/issues/151) (move error logging to the `pipe.Config.ErrorHandler` boundary) — independent bug, sequence alongside or before the rest of Phase 2 so the new errors below are observable by default (Final Design §6)
 - [ ] Implement public `MarshalMiddleware(registry, marshaler) Middleware` with fail-loud input/output checks (Final Design §3)
 - [ ] Implement `Router` changes (`Marshaler`/`DisableMarshaler` config, install `MarshalMiddleware` by default, simplify `process()`)
 - [ ] Retype `message/jsonschema`'s three middleware constructors (mechanical only — Final Design §5)

--- a/docs/procedures/README.md
+++ b/docs/procedures/README.md
@@ -12,6 +12,7 @@ Modular procedure library for gopipe development. Reusable across projects.
 | [documentation.md](documentation.md) | Docs | Structure, templates, ADRs |
 | [planning.md](planning.md) | Planning | Plan files and structure |
 | [adr.md](adr.md) | ADRs | Architecture Decision Records |
+| [dependencies.md](dependencies.md) | Dependencies | External dependency and package boundary rules |
 | [release.md](release.md) | Releases | Release and hotfix procedures |
 | [feature-release.md](feature-release.md) | Feature Release | Merge feature branches with history cleanup |
 

--- a/docs/procedures/dependencies.md
+++ b/docs/procedures/dependencies.md
@@ -1,0 +1,52 @@
+# Dependency & Package Boundary Procedures
+
+Actionable checklist for external dependencies and package placement across the gopipe multi-module repository. Full rationale and case studies: [ADR 0028](../adr/0028-external-dependency-policy.md).
+
+## Before Adding an External Dependency
+
+### `channel` and `pipe`
+
+- [ ] Stop. Zero external dependencies allowed — including test-only. No exceptions, regardless of how small or well-regarded the library is. Verify: `cat channel/go.mod pipe/go.mod` should show no `require` beyond `github.com/fxsml/gopipe/channel` (for `pipe`).
+
+### `message` (core)
+
+- [ ] Does this dependency deliver real, individually justified benefit against its transitive cost? (`google/uuid` is the reference example: small, stable, clear win, no controversy.)
+- [ ] Check the footprint at the **module** level, not the direct `require` line — a small direct dependency can still pull in a heavy transitive graph:
+  ```bash
+  cd message && GOWORK=off go list -deps ./... | grep -v "^github.com/fxsml"
+  ```
+- [ ] Does it duplicate a capability gopipe already has via stdlib or its own abstractions (`message.Logger`, stdlib `encoding/json`)? A dependency that ships its own logging framework or its own JSON codec is a much harder sell than one that doesn't, even at the same raw dependency count — see ADR 0028's `cloudevents/sdk-go` case (`zap`, `json-iterator`) vs. `santhosh-tekuri/jsonschema` (mostly `golang.org/x/text`, already stdlib-adjacent) for the concrete comparison.
+
+### Any package's public API
+
+- [ ] Does any exported function or type take or return a type from an external library? Check directly, don't eyeball it:
+  ```bash
+  grep -n "^func \|^type " path/to/package/*.go | grep -v "_test.go"
+  ```
+  Cross-reference the return/parameter types against the package's imports. If an external type appears in an exported signature, **this package does not belong in this repository.** It belongs in its own repository, named `gopipe-<name>`, following the convention already established by `gopipe-azservicebus`.
+
+## Before Shipping a New Subpackage
+
+A subpackage must clear **both** of the following — passing one without the other is not enough:
+
+- [ ] **Dependency-clean**, per the checks above.
+- [ ] **Proven, not just plausible, real-world use.** Check actual call sites, not intent or design docs:
+  ```bash
+  grep -rn "packagename\." --include="*.go" . | grep -v "_test.go"
+  ```
+  Zero or near-zero real (non-test) call sites is a signal the subpackage is speculative, however clean its dependency story is. This is what caught `Router`'s handler-level `Matcher` parameter (`#152`) — every real call site passed `nil`.
+- [ ] The subpackage's own design is mature, independent of whether its underlying dependency is. `message/jsonschema` is the cautionary example: `santhosh-tekuri/jsonschema` itself was a reasonable dependency — the wrapper `Registry` gopipe built around it had a real design flaw (a second, parallel eventType↔type mapping that could silently drift from `Router`'s own registry). The dependency passed; the package didn't.
+
+## Quick Reference
+
+| Module | External deps allowed? | Notes |
+|---|---|---|
+| `channel` | No | Stdlib only, no exceptions, including tests |
+| `pipe` | No | Stdlib only, plus `channel` |
+| `message` (core) | Yes, curated | Individually justified per dependency, e.g. `google/uuid` |
+| Any subpackage whose public API exposes a foreign type | N/A | Doesn't live in this repo — separate `gopipe-<name>` repository |
+
+## Related
+
+- [ADR 0028](../adr/0028-external-dependency-policy.md) — full decision record, four rules, consequences
+- [ADR 0027](../adr/0027-json-schema-validation.md) — superseded by 0028; the `message/jsonschema` parallel-registry case study


### PR DESCRIPTION
## Summary

Planning documents only — no implementation in this PR. Addresses [#125](https://github.com/fxsml/gopipe/issues/125) (unifying `Message`/`RawMessage`), reduced in scope and reframed around a broader finding: several parts of the current `message` package design were built ahead of real need (an orchestration layer, a handler-level matcher nobody uses, dependency choices never individually justified), surfaced while working through the marshaling redesign.

### [`docs/plans/engine-removal.md`](docs/plans/engine-removal.md)

Removes `message.Engine` entirely rather than mechanically porting it to the new `Message` contract — legacy overengineering (orchestration layer, `Plugin` abstraction, dedicated-pool marshal stages built ahead of need). Must land first since `Engine` depends on `RawMessage`, which the next doc drops. `Router`, `Merger`, `Distributor` are unaffected. Tracked in [#147](https://github.com/fxsml/gopipe/issues/147).

### [`docs/plans/marshaling-strategy.md`](docs/plans/marshaling-strategy.md)

Adopts #125's proposal directly: `Message` becomes a concrete struct (`Data any`, no more `TypedMessage[T]` generic) with a `Raw()` accessor. `UnmarshalPipe`/`MarshalPipe` are kept (in production use) but ported to a uniform `*Message` → `*Message` signature, failing loudly (`ErrDataNotRaw`/`ErrDataNotTyped`) on a raw/typed mismatch instead of silently accepting either. `Router` performs unmarshal/marshal via a public, swappable `MarshalMiddleware`, installed by default and disabled with a single `DisableMarshaler` flag. Documents rejected intermediate designs, a full middleware impact analysis (`Subject()` requires `DisableMarshaler: true`; everything else unaffected), and a benchmark plan. Tracked in [#148](https://github.com/fxsml/gopipe/issues/148) and [#149](https://github.com/fxsml/gopipe/issues/149).

Also surfaced and filed as independent, non-blocking findings:
- [#151](https://github.com/fxsml/gopipe/issues/151) — `Router` silently swallows errors from `Use()` middleware (existing bug, unrelated to this redesign but a practical prerequisite for the new errors above being observable)
- [#152](https://github.com/fxsml/gopipe/issues/152) — drop `Router.AddHandler`'s matcher parameter (Engine-inherited, zero real usage anywhere in the repo)
- [#153](https://github.com/fxsml/gopipe/issues/153) — deferred decision on `Merger`/`Distributor`/`Matcher`/`message/match`'s fate

### [`docs/adr/0028-external-dependency-policy.md`](docs/adr/0028-external-dependency-policy.md)

A repo-wide policy for dependency and package placement, prompted by the above review: `channel`/`pipe` stay stdlib-only with no exceptions; `message` core allows curated, individually-justified external deps; no gopipe package's public API may ever expose a foreign library type (those live in their own repo, mirroring `gopipe-azservicebus`); a subpackage needs proven real-world use, not just dependency-cleanliness, to ship. Supersedes [ADR 0027](docs/adr/0027-json-schema-validation.md) — `message/jsonschema` is removed (its `Registry` duplicates `Router`'s own eventType→handler bookkeeping in a second, independently-configured mapping that can silently drift). Tracked in [#154](https://github.com/fxsml/gopipe/issues/154) (index) through [#155](https://github.com/fxsml/gopipe/issues/155)–[#158](https://github.com/fxsml/gopipe/issues/158).

## Test plan

- [x] Docs-only change; `make test && make build && make vet` pass unaffected