### PR TITLE
docs(skills): cross-reference dependency procedure

### DIFF
--- a/.claude/skills/developing-go-code/SKILL.md
+++ b/.claude/skills/developing-go-code/SKILL.md
@@ -115,4 +115,5 @@ return &Message{Attributes: maps.Clone(msg.Attributes)}
 
 - @../docs/procedures/coding.md — behavioral rules: simplicity, surgical changes, scope discipline
 - @../docs/procedures/go.md — full Go standards, deprecation, error handling
+- @../docs/procedures/dependencies.md — external dependency and package boundary rules
 - @../AGENTS.md — architecture decisions, common mistakes, naming decisions

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -86,7 +86,7 @@ Report:
 
 - Never implement more than what the issue describes
 - Every change must have a test that would have caught the bug or validates the feature
-- Do not add dependencies without discussing first
+- Do not add dependencies without discussing first — see dependencies.md for the checklist
 - If the issue touches public API or inter-package contracts, flag it before proceeding
 
 ## Reference Procedures
@@ -94,3 +94,4 @@ Report:
 - @../docs/procedures/coding.md — behavioral rules: simplicity, scope discipline, TDD
 - @../docs/procedures/go.md — Go standards, godoc, testing patterns
 - @../docs/procedures/git.md — branch naming, commit format, approval gates
+- @../docs/procedures/dependencies.md — external dependency and package boundary rules


### PR DESCRIPTION
## Summary

- `developing-go-code` and `implement` skills didn't point to the new `docs/procedures/dependencies.md` checklist (added in the marshaling-strategy PR alongside ADR 0028), even though both apply directly to the upcoming package-boundary work (#155-#158).
- Adds a `dependencies.md` reference to each skill's Reference Procedures / hard-rules section.

## Test plan

- [x] `make test && make build && make vet` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01265k5Mf1xxM5o7izHXwEzE)_