### PR TITLE
docs(adr): add ADR 0029, reconcile #120 interface refactor proposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,53 @@ engine.AddSubscriber("orders", subscriber)
 
 **Why:** Doesn't handle leader election, dynamic scaling. External concern.
 
+### Semantic Interfaces (Filter/Mapper/Expander/Source/Processor/Sink) + `*Pipe` Suffix Rename
+
+```go
+// REJECTED
+type Mapper[In, Out any] interface { Map(in In) Out }
+type MapperPipe[In, Out any] struct{ /* sole implementation */ }
+func (m *MapperPipe[In, Out]) Map(in In) Out          { ... }
+func (m *MapperPipe[In, Out]) Pipe() Pipe[In, Out]    { ... }
+```
+
+**Why:** Violates documented Go convention — interfaces belong in the package that *uses* them, not beside their only implementation (go.dev Code Review Comments: "do not define interfaces before they are used"). The "direct invocation for testing" rationale is also moot: constructors already take the raw handler function, so callers already hold it. See [ADR 0029](docs/adr/0029-channel-pipe-interface-boundaries.md).
+
+### Producer/Trigger Separation
+
+```go
+// REJECTED
+type TriggerFunc func(ctx context.Context, trigger func()) error
+func NewProducer[Out any](source Source[Out], trigger TriggerFunc) *Producer[Out]
+package trigger // Interval, Cron, Immediate, OnDemand
+```
+
+**Why:** No proven real-world need — the one real periodic-generation use case found rolled entirely bespoke scheduling logic instead of using `pipe.Generator`. See [ADR 0029](docs/adr/0029-channel-pipe-interface-boundaries.md).
+
+### Unified Process() Method via Type Embedding
+
+```go
+// REJECTED
+func (f *FilterPipe[T]) Process(ctx context.Context, in T) ([]T, error) {
+    if f.Filter(in) {
+        return []T{in}, nil
+    }
+    return nil, nil
+}
+```
+
+**Why:** Wraps every pure operation's single value in a slice just to satisfy a common `Processor` interface, and blurs the pure/impure distinction. No clear benefit over explicit composition. See [ADR 0029](docs/adr/0029-channel-pipe-interface-boundaries.md).
+
+## Deferred Ideas (No Proven Need Yet)
+
+Surfaced during design exploration, not built — no real usage evidence, unlike the Rejected Alternatives above which have a specific reason *against* them. Revisit only if a concrete need appears.
+
+- **Router `PreMap`/`PostMap`** — optional type-conversion hooks on `RouterConfig` so handlers work with domain-specific types while `Router` converts at the boundary. Middleware may already cover this.
+- **Conditional/branching pipes** — `pipe.NewBranch(predicate, truePipe, falsePipe)`, route to one of two pipes by predicate.
+- **Error-recovery pipes** — `pipe.NewRecover(mainPipe, fallbackFunc)`, call a fallback on error instead of failing the pipeline. Distinct from `middleware.Recover` (panics, not errors).
+
+See [ADR 0029](docs/adr/0029-channel-pipe-interface-boundaries.md) for full context.
+
 ## Naming Decisions
 
 | Chosen | Rejected | Reason |
@@ -241,6 +288,8 @@ engine.AddSubscriber("orders", subscriber)
 | `Use()` | `ApplyMiddleware()` | Standard Go pattern (gin, echo, etc.) |
 | `DotNaming` | `KebabNaming` | Correctly describes output format: `order.created` (dots) |
 | `KebabNaming` | — | Fixed: now produces true kebab-case: `order-created` (hyphens) |
+| `channel.Transform`/`Process`/`Sink` (kept) | `Map`/`Expand`/`Drain` (channel-only rename) | Would break existing `pipe.NewTransformPipe`/`NewProcessPipe`/`NewSinkPipe` symmetry — see ADR 0029 |
+| `channel.Switch` (replaces `Route`, planned) | — | Avoids clash with `message.Router` — see ADR 0029 |
 
 ## File Organization
 

--- a/docs/adr/0029-channel-pipe-interface-boundaries.md
+++ b/docs/adr/0029-channel-pipe-interface-boundaries.md
@@ -1,0 +1,38 @@
+# ADR 0029: Channel/Pipe Interface and Naming Boundaries
+
+**Date:** 2026-07-26
+**Status:** Proposed
+
+## Context
+
+Issue [#120](https://github.com/fxsml/gopipe/issues/120) proposed a broad redesign of `channel`, `pipe`, and `middleware` on a branch that never merged (documentation-only, stale, since deleted). As part of v1 preparation, alongside the [channel package usage audit](https://github.com/fxsml/gopipe/issues/164), that proposal was re-evaluated against the current codebase and documented Go interface guidance. Full rationale, sources, and preserved-but-unadopted ideas: [Channel/Pipe Interface Consolidation plan](../plans/channel-pipe-interface-consolidation.md).
+
+## Decision
+
+1. **Keep `channel.Transform`/`Process`/`Sink`/`Drain` as-is.** They already mirror `pipe.NewTransformPipe`/`NewProcessPipe`/`NewSinkPipe` — renaming only `channel`'s side would break that symmetry.
+2. **No formal semantic interfaces** (`Filter`/`Mapper`/`Expander`/`Source`/`Processor`/`Sink`) **and no `*Pipe`-suffix rename.** Would define interfaces beside their sole implementation, with no consumer needing them — contrary to documented Go convention.
+3. **No `Producer`/`Trigger` abstraction.** No proven real-world need.
+4. **`channel.Route` → `channel.Switch`.** Resolves a real naming collision with `message.Router`. Tracked in #165.
+5. **`channel.GroupBy` relocates to `pipe`** as `NewGroupByPipe`/`GroupByConfig`, matching the existing `NewBatchPipe`/`BatchConfig` shape. Tracked in #162.
+6. **Keep the middleware type-alias fix** (a real Go generics assignability constraint), narrowly scoped. Full `middleware`-module consolidation is deferred pending a `message/middleware` rule-4 evaluation that isn't tracked yet.
+
+## Consequences
+
+**Breaking Changes:**
+- `channel.Route` renamed to `channel.Switch` (#165)
+- `channel.GroupBy` moves to `pipe` (#162)
+- No changes to `Transform`, `Process`, `Sink`, `Drain`, or any `pipe` constructor names
+
+**Benefits:**
+- `channel`/`pipe` naming symmetry stays intact
+- Avoids interface and abstraction surface with no proven consumer
+- Resolves the `Route`/`Router` naming collision
+
+**Drawbacks:**
+- Discards several months of exploratory design writing from the retired branch; superseded content is preserved in the consolidation plan and `AGENTS.md`, not repeated here
+
+## Links
+
+- [Channel/Pipe Interface Consolidation plan](../plans/channel-pipe-interface-consolidation.md) — full rationale, sources, deferred ideas
+- Related: [#120](https://github.com/fxsml/gopipe/issues/120), [#164](https://github.com/fxsml/gopipe/issues/164), [#160](https://github.com/fxsml/gopipe/issues/160)–[#163](https://github.com/fxsml/gopipe/issues/163), [#165](https://github.com/fxsml/gopipe/issues/165)
+- Related: ADR 0028 (External Dependency Policy) — same "proven, not just plausible" standard applied here to interface surface

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ See [ADR Procedures](../procedures/adr.md) for details.
 | [0027](0027-json-schema-validation.md) | JSON Schema Validation | Superseded by ADR 0028 |
 | [0026](0026-acking-middleware-outermost.md) | Acking Middleware Outermost | Proposed |
 | [0028](0028-external-dependency-policy.md) | External Dependency Policy | Proposed |
+| [0029](0029-channel-pipe-interface-boundaries.md) | Channel/Pipe Interface and Naming Boundaries | Proposed |
 
 ## History
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -15,6 +15,7 @@
 | [redis-transactions](redis-transactions.md) | Redis Integration | Proposed |
 | [oauth2-cloudevents](oauth2-cloudevents.md) | OAuth2 CloudEvents Integration | Proposed |
 | [webhook-abuse-protection](webhook-abuse-protection.md) | Webhook Abuse Protection Handshake | Proposed |
+| [channel-pipe-interface-consolidation](channel-pipe-interface-consolidation.md) | Channel/Pipe Interface Consolidation | In Progress |
 
 ## Agent Guidance
 

--- a/docs/plans/channel-pipe-interface-consolidation.md
+++ b/docs/plans/channel-pipe-interface-consolidation.md
@@ -1,0 +1,90 @@
+# Plan: Channel/Pipe Interface Consolidation
+
+**Status:** In Progress
+**Related ADRs:** [0029](../adr/0029-channel-pipe-interface-boundaries.md)
+
+## Overview
+
+Issue [#120](https://github.com/fxsml/gopipe/issues/120) and its branch `claude/refactor-pipe-interfaces-7NuOQ` proposed a broad redesign of `channel`, `pipe`, and `middleware`: formal pure/impure semantic interfaces, a `Producer`/`Trigger` abstraction, and a `channel`-package renaming pass. None of its seven draft ADRs (0024–0030) or four plans (0013–0016) ever merged to `develop` — the branch was documentation-only (zero `.go` changes across 13 files) and stale (diverged 2026-01-28, last commit 2026-02-02, no PR opened). Its ADR numbers (0024–0028) and plan number (0013) have since been reused on `develop` for unrelated work, and the branch itself has been deleted (no GitHub archive mechanism exists short of keeping it around).
+
+This plan re-evaluates that proposal end to end against the current codebase and documented Go interface guidance — in conjunction with the [channel package usage audit](https://github.com/fxsml/gopipe/issues/164) (#160–#163) — and is the durable record of what was proposed, what survived, and why, now that the source branch is gone. [ADR 0029](../adr/0029-channel-pipe-interface-boundaries.md) records only the resulting decisions; this plan carries the reasoning, sources, and everything not adopted.
+
+## Goals
+
+1. Decide, with evidence rather than preference, which parts of the old proposal to adopt, reject, or defer
+2. Preserve enough of the retired branch's content that nothing useful is lost on deletion
+3. Track the resulting concrete changes to closure
+
+## Decisions & Rationale
+
+### 1. Preserve `channel`/`pipe` verb symmetry — reject the `channel`-only renaming pass
+
+`pipe/pipe.go` already exposes `NewTransformPipe`, `NewProcessPipe`, and `NewSinkPipe` — the same verbs as `channel.Transform`, `channel.Process`, `channel.Sink`. This mirrors `Merge`/`Merger`: the same word names the same operation at both purity tiers (pure/stateless in `channel`, impure/stateful in `pipe`). The old branch's renames (`Transform`→`Map`, `Process`→`Expand`, `Sink`→`Drain`, `Drain`→`Drop`) only touched `channel`'s side, which would have broken that symmetry; renaming both sides would double the churn for names that are already clear. **Kept as-is.**
+
+### 2. Reject formal semantic interfaces and the `*Pipe`-suffix rename
+
+The [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) wiki: *"Go interfaces generally belong in the package that uses values of the interface type, not the package that implements those values... Do not define interfaces before they are used."* It labels the opposite — a producer package defining an interface next to its only implementation — "DO NOT DO IT!!!". The old branch's `Mapper`/`Expander`/`Filter`/`Source`/`Processor`/`Sink` interfaces would have lived in `pipe` beside their sole implementations (`MapperPipe`, etc.), with no consumer needing them for polymorphism. Their stated purpose — direct invocation without pipe machinery, for testing — is also moot: every constructor (e.g. `NewProcessPipe(handleFunc, cfg)`) already takes the raw handler function as a parameter, so callers already hold it. The underlying pure/impure *observation* (`channel` = no ctx/error, `pipe` = ctx/error) is correct and already documented in `channel/doc.go`/`pipe/doc.go` — it doesn't need formal interfaces to be true.
+
+### 3. Reject `Producer`/`Trigger` separation
+
+No proven real-world need. The one production periodic-generation use case identified (in the production reference repository used for v1 evidence-gathering) implements its own scheduling entirely from scratch — distributed-lock renewal, a custom cycle loop, its own config — without using `pipe.Generator` or `channel.FromFunc`. A generic `trigger.Interval`/`trigger.Cron` abstraction would not have simplified that real case; the complexity lived in domain logic, not in "when to trigger."
+
+### 4. Adopt `channel.Route` → `channel.Switch`
+
+Real naming collision: `channel.Route` (a function) and `message.Router` (a type) coexist across the module family and are conceptually unrelated (index-based fan-out vs. event-type routing with handlers). `Switch` reads unambiguously as "select one output by index," matching Go's own `switch` statement. No symmetry is broken — `pipe`'s fan-out counterpart is already named differently (`Distributor`, matcher-based selection, a distinct concept). This completes a three-way fan-out vocabulary: `Broadcast` (copy to all), `Switch` (select one by index), `pipe.Distributor` (select one by matcher). Tracked in #165.
+
+### 5. `GroupBy` relocates to `pipe`, existing constructor pattern, no new interface
+
+Tracked in #162. Lands as `NewGroupByPipe`/`GroupByConfig`, matching the shape `NewBatchPipe`/`BatchConfig` already uses — a concrete constructor returning a concrete struct, consistent with decision 2 and Code Review Comments' guidance that implementing packages return concrete types.
+
+### 6. Keep the middleware type-alias fix, narrowly scoped — defer full `middleware` module consolidation
+
+The old branch's middleware work bundled two different things: (a) a real Go generics constraint and its fix, and (b) a structural consolidation of `pipe/middleware` and `message/middleware` into one top-level `middleware` module. Only (a) is adopted.
+
+The constraint is real, not a style preference. Raw function types are not assignable to a named generic type in variadic parameters:
+
+```go
+// Does NOT work — raw signature, fails at the call site
+func Retry[In, Out any]() func(func(context.Context, In) ([]Out, error)) func(context.Context, In) ([]Out, error)
+pipe.Use(processor, Retry[string, string]())  // ERROR: type mismatch
+
+// Works — middleware constructors return pipe.ProcessFunc directly
+func Retry[In, Out any]() func(pipe.ProcessFunc[In, Out]) pipe.ProcessFunc[In, Out]
+pipe.Use(processor, Retry[string, string]())  // OK: assignable to pipe.Middleware
+```
+
+Rule going forward: any future `middleware` package must define no types of its own and use `pipe.ProcessFunc[In, Out]` directly; a message-aware variant needs only a type *alias* (`type Middleware = pipe.Middleware[*message.Message, *message.Message]`), not a new type, to stay interchangeable with the generic form.
+
+**Not adopted yet:** the full `middleware`-module consolidation (moving `pipe/middleware` and `message/middleware` into one tree, third-party-integration isolation, deprecating the old packages). ADR 0028's rule 4 ("proven, not just plausible, real-world use") applies here too — `message/middleware`'s middlewares are meant to be evaluated individually before any consolidation decision, and that evaluation has no tracking issue yet. Consolidating before knowing which middlewares survive risks packaging together things that don't all belong. Revisit once that evaluation is tracked and run.
+
+## Preserved for Later: Unevaluated Ideas from the Retired Branch
+
+Outside this plan's scope, never evaluated against real usage. Recorded so they aren't lost, not acted on:
+
+- **Router `PreMap`/`PostMap`** — optional type-conversion hooks on `RouterConfig` so handlers can work with domain-specific types while `Router` converts at the boundary. The original proposal itself left this undecided ("middleware may be sufficient for enrichment/normalization use cases").
+- **Conditional/branching pipes** (`pipe.NewBranch(predicate, truePipe, falsePipe)`) — route to one of two pipes by predicate. No evidence of need surfaced during this review.
+- **Error-recovery pipes** (`pipe.NewRecover(mainPipe, fallbackFunc)`) — on error, call a fallback instead of failing the pipeline. Distinct from `middleware.Recover` (panic recovery, not error recovery). No evidence of need surfaced during this review.
+
+One related idea from the same source was already rejected by its own authors, and that reasoning holds (recorded in `AGENTS.md` Rejected Alternatives): giving every pipe type a `Process()` method via composition (so any pipe satisfies a `Processor` interface) was rejected for wrapping pure single-value results in a slice unnecessarily and blurring the pure/impure distinction decision 2 depends on.
+
+## Tasks
+
+- [ ] #160 — Remove `channel.FromRange`
+- [ ] #161 — Remove `channel.Cancel`
+- [ ] #162 — Relocate `channel.GroupBy` to `pipe`
+- [ ] #163 — Fix `channel.ToSlice`
+- [ ] #165 — Rename `channel.Route` to `channel.Switch`
+- [ ] Close #120, superseded by this plan and #164
+- [ ] File a tracking issue for the `message/middleware` rule-4 evaluation gating decision 6's consolidation question (not yet filed)
+
+## Acceptance Criteria
+
+- [ ] All linked issues closed
+- [ ] `docs/adr/0029-channel-pipe-interface-boundaries.md` reflects final state
+- [ ] `make test && make build && make vet` pass
+
+## Sources
+
+- [Go Code Review Comments — Interfaces](https://go.dev/wiki/CodeReviewComments)
+- [Effective Go — Interface names](https://go.dev/doc/effective_go)
+- Production reference repository (v1 evidence-gathering) and `gopipe-azservicebus` — see #164


### PR DESCRIPTION
## Summary

- Adds ADR 0029, reconciling the stale, never-merged `claude/refactor-pipe-interfaces-7NuOQ` branch (issue #120) against the current codebase and documented Go interface guidance, alongside the channel package usage audit (#164)
- Rejects: semantic interfaces (`Filter`/`Mapper`/`Expander`/`Source`/`Processor`/`Sink`) + `*Pipe`-suffix rename (violates Go interface-placement convention), `Producer`/`Trigger` separation (no proven need), and `channel`-only verb renames `Map`/`Expand`/`Drain`/`Drop` (would break existing `channel`/`pipe` naming symmetry)
- Adopts: `channel.Route` → `channel.Switch` (#165) and `GroupBy` → `pipe.NewGroupByPipe`/`GroupByConfig` (#162)
- Updates `docs/adr/README.md` index and `AGENTS.md` (Rejected Alternatives, Naming Decisions) accordingly
- Updates issue #120's description to record this outcome (not part of this diff — done directly on the issue)

## Test plan

- [ ] Docs-only change — `make docs-lint` clean, no code affected
- [ ] Links in ADR 0029 and AGENTS.md resolve correctly

Refs #120, #162, #165, #164