### PR TITLE
docs: ADR 0030 and consolidation plan update for Merger/Distributor/Matcher removal

### DIFF
--- a/docs/adr/0030-drop-merger-distributor-matcher.md
+++ b/docs/adr/0030-drop-merger-distributor-matcher.md
@@ -1,0 +1,35 @@
+# ADR 0030: Drop Merger, Distributor, and Matcher
+
+**Date:** 2026-07-26
+**Status:** Proposed
+
+## Context
+
+`message.Merger`, `message.Distributor`, `pipe.Merger`, `pipe.Distributor`, and the `Matcher` interface (`message/match`) were built as `message.Engine`'s internal fan-in/fan-out plumbing (ADR 0020/0022) and never independently adopted. Checked against real-world evidence — gopipe's own code, a production reference repository, and the `gopipe-azservicebus` broker adapter: zero usage of any of them outside `Engine` itself. `pipe.Distributor`'s only consumer is `message.Distributor`. `pipe.Merger` appeared to have independent evidence via `examples/03-merger`, but its `AddInput` calls all happen before `Merge()` starts — a static merge, functionally identical to `channel.Merge`, that never exercises dynamic add-after-start, the one capability that actually distinguishes it. `Matcher`'s only surviving consumer was `Distributor.AddOutput(matcher)`. Full evidence: [#153](https://github.com/fxsml/gopipe/issues/153).
+
+## Decision
+
+Remove `message.Merger`, `message.Distributor`, `pipe.Merger`, `pipe.Distributor`, the `Matcher` interface, and the `message/match` package (`Types`, `All`, `Any`, `Sources`, `Like`).
+
+`channel.Merge` and `channel.Switch` (renamed from `Route`, [#165](https://github.com/fxsml/gopipe/issues/165)) already cover every real, evidenced fan-in/fan-out need found in this audit. `examples/03-merger` is rewritten to demonstrate `channel.Merge` directly.
+
+All of this is recoverable from git history if a real, evidenced need for dynamic fan-in or matcher-based fan-out ever appears — a reversible cut, not a one-way door.
+
+## Consequences
+
+**Breaking Changes:**
+- Removes 4 types, 1 interface, 1 subpackage (pre-v1, acceptable)
+- `examples/03-merger` rewritten, no longer demonstrates `pipe.Merger`
+
+**Benefits:**
+- Removes unproven API surface, consistent with ADR 0028 rule 4 ("proven, not just plausible, real-world use")
+- `channel.Merge`/`Switch` already serve the evidenced need with less API surface
+
+**Drawbacks:**
+- Dynamic runtime fan-in (add an input after the merge has started) and matcher-based fan-out have no replacement if a real need for either ever appears — would need reimplementing from git history
+
+## Links
+
+- Decided in [#153](https://github.com/fxsml/gopipe/issues/153) — full evidence and reasoning
+- Related: [#152](https://github.com/fxsml/gopipe/issues/152) (`Router` matcher param — same origin pattern), [#165](https://github.com/fxsml/gopipe/issues/165) (`Switch` rename — fan-out vocabulary now two-way)
+- Related: ADR 0028 (rule 4, the standard applied here), ADR 0029 (`channel`/`pipe` interface boundaries — a related but separate decision)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,7 @@ See [ADR Procedures](../procedures/adr.md) for details.
 | [0026](0026-acking-middleware-outermost.md) | Acking Middleware Outermost | Proposed |
 | [0028](0028-external-dependency-policy.md) | External Dependency Policy | Proposed |
 | [0029](0029-channel-pipe-interface-boundaries.md) | Channel/Pipe Interface and Naming Boundaries | Proposed |
+| [0030](0030-drop-merger-distributor-matcher.md) | Drop Merger, Distributor, and Matcher | Proposed |
 
 ## History
 

--- a/docs/plans/channel-pipe-interface-consolidation.md
+++ b/docs/plans/channel-pipe-interface-consolidation.md
@@ -19,7 +19,7 @@ This plan re-evaluates that proposal end to end against the current codebase and
 
 ### 1. Preserve `channel`/`pipe` verb symmetry — reject the `channel`-only renaming pass
 
-`pipe/pipe.go` already exposes `NewTransformPipe`, `NewProcessPipe`, and `NewSinkPipe` — the same verbs as `channel.Transform`, `channel.Process`, `channel.Sink`. This mirrors `Merge`/`Merger`: the same word names the same operation at both purity tiers (pure/stateless in `channel`, impure/stateful in `pipe`). The old branch's renames (`Transform`→`Map`, `Process`→`Expand`, `Sink`→`Drain`, `Drain`→`Drop`) only touched `channel`'s side, which would have broken that symmetry; renaming both sides would double the churn for names that are already clear. **Kept as-is.**
+`pipe/pipe.go` already exposes `NewTransformPipe`, `NewProcessPipe`, and `NewSinkPipe` — the same verbs as `channel.Transform`, `channel.Process`, `channel.Sink`: the same word names the same operation at both purity tiers (pure/stateless in `channel`, impure/stateful in `pipe`). The old branch's renames (`Transform`→`Map`, `Process`→`Expand`, `Sink`→`Drain`, `Drain`→`Drop`) only touched `channel`'s side, which would have broken that symmetry; renaming both sides would double the churn for names that are already clear. **Kept as-is.** (`Merge`/`Merger` was originally cited here as another instance of the same pattern; `pipe.Merger` is now dropped per #153, so this argument rests on `Transform`/`Process`/`Sink` alone — still sufficient on its own.)
 
 ### 2. Reject formal semantic interfaces and the `*Pipe`-suffix rename
 
@@ -31,7 +31,9 @@ No proven real-world need. The one production periodic-generation use case ident
 
 ### 4. Adopt `channel.Route` → `channel.Switch`
 
-Real naming collision: `channel.Route` (a function) and `message.Router` (a type) coexist across the module family and are conceptually unrelated (index-based fan-out vs. event-type routing with handlers). `Switch` reads unambiguously as "select one output by index," matching Go's own `switch` statement. No symmetry is broken — `pipe`'s fan-out counterpart is already named differently (`Distributor`, matcher-based selection, a distinct concept). This completes a three-way fan-out vocabulary: `Broadcast` (copy to all), `Switch` (select one by index), `pipe.Distributor` (select one by matcher). Tracked in #165.
+Real naming collision: `channel.Route` (a function) and `message.Router` (a type) coexist across the module family and are conceptually unrelated (index-based fan-out vs. event-type routing with handlers). `Switch` reads unambiguously as "select one output by index," matching Go's own `switch` statement. Tracked in #165.
+
+**Updated:** this decision originally framed `Switch` as completing a three-way fan-out vocabulary alongside `Broadcast` and `pipe.Distributor` ("select one by matcher"). `pipe.Distributor` (and `message.Distributor`, `message.Merger`, `pipe.Merger`, and `Matcher`/`message/match`) are now dropped entirely — decided in #153, zero evidence anywhere for matcher-based fan-out or dynamic add-after-start merging once checked properly (see #153 for the full reasoning, including why `pipe.Merger`'s one apparent example didn't actually hold up). The fan-out vocabulary is now two-way: `Broadcast` (copy to all) and `Switch` (select one by index) — both covered by real, evidenced usage.
 
 ### 5. `GroupBy` relocates to `pipe`, existing constructor pattern, no new interface
 
@@ -74,6 +76,7 @@ One related idea from the same source was already rejected by its own authors, a
 - [ ] #162 — Relocate `channel.GroupBy` to `pipe`
 - [ ] #163 — Fix `channel.ToSlice`
 - [ ] #165 — Rename `channel.Route` to `channel.Switch`
+- [ ] #153 — Drop `message.Merger`/`Distributor`, `pipe.Merger`/`Distributor`, `Matcher`/`message/match`
 - [ ] Close #120, superseded by this plan and #164
 - [ ] File a tracking issue for the `message/middleware` rule-4 evaluation gating decision 6's consolidation question (not yet filed)
 


### PR DESCRIPTION
## Summary

- Adds [ADR 0030](docs/adr/0030-drop-merger-distributor-matcher.md): drops `message.Merger`, `message.Distributor`, `pipe.Merger`, `pipe.Distributor`, and `Matcher`/`message/match` — decided in #153
- Updates `docs/plans/channel-pipe-interface-consolidation.md` to reflect that decision: fixes decision 4's now-stale "three-way fan-out vocabulary" (was `Broadcast`/`Switch`/`pipe.Distributor`, now just `Broadcast`/`Switch`), fixes the `Merge`/`Merger` precedent example in decision 1, adds #153 to the task list
- Updates `docs/adr/README.md` index

Related issue edits (already applied directly, not part of this diff): #153 (full rewrite, decided, ADR linked), #152 (corrected "kept, untouched" claims), #165 (corrected fan-out trio table).

## Test plan

- [ ] Docs-only change, no code affected