### PR TITLE
refactor(channel)!: rename Route to Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of silently falling back to a zero-value command when `msg.Data` is `nil` or does
   not type-assert to `*C`/`C` (#145)
 
+### Changed
+
+- **channel:** Renamed `Route` → `Switch` (breaking, pre-v1) — avoids naming collision with `message.Router`, which does event-type-based routing (a different mechanism). Behavior is unchanged. (#165)
+
 ## [0.18.0] - 2026-04-10
 
 ### Added

--- a/channel/doc.go
+++ b/channel/doc.go
@@ -11,11 +11,6 @@
 // batching, and more. All functions are pure and create new channels without
 // modifying inputs.
 //
-// [gopipe]: https://github.com/fxsml/gopipe
-// [channel]: https://pkg.go.dev/github.com/fxsml/gopipe/channel
-// [pipe]: https://pkg.go.dev/github.com/fxsml/gopipe/pipe
-// [message]: https://pkg.go.dev/github.com/fxsml/gopipe/message
-//
 // # Quick Start
 //
 //	// Generate, filter, transform, consume
@@ -30,7 +25,7 @@
 //
 // Transforms: [Filter], [Transform], [Process], [Flatten], [Buffer]
 //
-// Fan-out: [Broadcast], [Route]
+// Fan-out: [Broadcast], [Switch]
 //
 // Fan-in: [Merge]
 //
@@ -39,4 +34,9 @@
 // Batching: [Batch], [Collect], [GroupBy]
 //
 // For stateful components with lifecycle management, see the pipe package.
+//
+// [gopipe]: https://github.com/fxsml/gopipe
+// [channel]: https://pkg.go.dev/github.com/fxsml/gopipe/channel
+// [pipe]: https://pkg.go.dev/github.com/fxsml/gopipe/pipe
+// [message]: https://pkg.go.dev/github.com/fxsml/gopipe/message
 package channel

--- a/channel/switch.go
+++ b/channel/switch.go
@@ -1,9 +1,9 @@
 package channel
 
-// Route directs values from in to n output channels based on handle's index.
+// Switch directs values from in to n output channels based on handle's index.
 // Values with an index outside [0,n) are ignored. All returned channels
 // are closed after in is closed.
-func Route[T any](
+func Switch[T any](
 	in <-chan T,
 	handle func(item T) int,
 	n int,

--- a/channel/switch_test.go
+++ b/channel/switch_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-func TestRoute_BasicRouting(t *testing.T) {
+func TestSwitch_BasicRouting(t *testing.T) {
 	in := make(chan int)
-	outs := Route(in, func(v int) int { return v % 3 }, 3)
+	outs := Switch(in, func(v int) int { return v % 3 }, 3)
 
 	go func() {
 		for i := 0; i < 6; i++ {
@@ -54,9 +54,9 @@ func TestRoute_BasicRouting(t *testing.T) {
 	}
 }
 
-func TestRoute_OutOfRangeIsDropped(t *testing.T) {
+func TestSwitch_OutOfRangeIsDropped(t *testing.T) {
 	in := make(chan int)
-	outs := Route(in, func(v int) int { return -1 }, 2)
+	outs := Switch(in, func(v int) int { return -1 }, 2)
 
 	go func() {
 		in <- 1
@@ -71,9 +71,9 @@ func TestRoute_OutOfRangeIsDropped(t *testing.T) {
 	}
 }
 
-func TestRoute_OutputsClosedOnInputClose(t *testing.T) {
+func TestSwitch_OutputsClosedOnInputClose(t *testing.T) {
 	in := make(chan int)
-	outs := Route(in, func(v int) int { return 0 }, 2)
+	outs := Switch(in, func(v int) int { return 0 }, 2)
 	close(in)
 	// wait for each output to close (avoid blocking) using a timeout
 	for _, out := range outs {


### PR DESCRIPTION
Route(in, fn, n) selects one of n output channels by the index fn returns. The name collided conceptually with message.Router, which does event-type-based routing to handlers -- a different mechanism (matcher/type dispatch vs. plain index selection).

Switch reads unambiguously as "select one output by index", mirroring Go's own switch statement, and removes the collision. Behavior is unchanged, only the name.

Closes #165