### PR TITLE
fix(ci): checkout develop branch in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: develop
           fetch-depth: 1
 
       - name: Run Claude Code


### PR DESCRIPTION
For issue_comment and issues triggers, GitHub always runs the workflow from the default branch (main). Without an explicit ref, Claude checks out main and branches from there instead of develop.