### PR TITLE
feat(channel)!: remove FromRange Python-style variadic overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **channel:** Renamed `Route` → `Switch` (breaking, pre-v1) — avoids naming collision with `message.Router`, which does event-type-based routing (a different mechanism). Behavior is unchanged. (#165)
 
+### Removed
+
+- **channel:** `FromRange` (Python-style variadic-overload range constructor; the only function in `channel` with argument-count-dependent dispatch/panic-based validation). Breaking change, pre-v1. Use `FromValues` or `FromSlice` with a local loop instead. (#160)
+
 ## [0.18.0] - 2026-04-10
 
 ### Added

--- a/channel/doc.go
+++ b/channel/doc.go
@@ -14,14 +14,14 @@
 // # Quick Start
 //
 //	// Generate, filter, transform, consume
-//	in := channel.FromRange(10)
+//	in := channel.FromValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 //	filtered := channel.Filter(in, func(i int) bool { return i%2 == 0 })
 //	transformed := channel.Transform(filtered, func(i int) string { return fmt.Sprint(i) })
 //	<-channel.Sink(transformed, func(s string) { fmt.Println(s) })
 //
 // # Categories
 //
-// Sources: [FromSlice], [FromRange], [FromValues], [FromFunc]
+// Sources: [FromSlice], [FromValues], [FromFunc]
 //
 // Transforms: [Filter], [Transform], [Process], [Flatten], [Buffer]
 //

--- a/channel/from.go
+++ b/channel/from.go
@@ -27,63 +27,6 @@ func FromValues[T any](
 	return FromSlice(values)
 }
 
-// FromRange returns a channel that emits a sequence of integers.
-// Usage:
-//
-//	FromRange(to)              // emits 0, 1, ..., to-1 (step=1)
-//	FromRange(from, to)        // emits from, from+1, ..., to-1 (step=1)
-//	FromRange(from, to, step)  // emits from, from+step, ... < to
-//
-// If step > 0, emits ascending values: from, from+step, ... < to
-// If step < 0, emits descending values: from, from+step, ... > to
-// If step == 0, panics.
-//
-// The channel is closed after all values have been sent.
-// Panics if called with zero or more than three arguments.
-func FromRange(
-	i ...int,
-) <-chan int {
-	var from, to, step int
-	switch len(i) {
-	case 0:
-		panic("FromRange requires at least 1 integer argument")
-	case 1:
-		from = 0
-		to = i[0]
-		step = 1
-	case 2:
-		from = i[0]
-		to = i[1]
-		step = 1
-	case 3:
-		from = i[0]
-		to = i[1]
-		step = i[2]
-	default:
-		panic("FromRange accepts at most 3 integer arguments")
-	}
-	out := make(chan int)
-
-	if step == 0 {
-		panic("FromRange step must not be null")
-	}
-
-	go func() {
-		defer close(out)
-		if step < 0 {
-			for j := from; j > to; j += step {
-				out <- j
-			}
-			return
-		}
-		for j := from; j < to; j += step {
-			out <- j
-		}
-	}()
-
-	return out
-}
-
 // FromFunc generates values by repeatedly calling the handle function
 // until context cancellation.
 func FromFunc[T any](

--- a/channel/from_test.go
+++ b/channel/from_test.go
@@ -33,46 +33,6 @@ func TestFromSlice(t *testing.T) {
 	}
 }
 
-func TestFromRange(t *testing.T) {
-	cases := []struct {
-		name   string
-		args   []int
-		expect []int
-	}{
-		{"empty range", []int{0}, []int{}},
-		{"single value", []int{5, 6, 1}, []int{5}},
-		{"step 1", []int{0, 3, 1}, []int{0, 1, 2}},
-		{"step 2", []int{0, 5, 2}, []int{0, 2, 4}},
-		{"default from/step", []int{3}, []int{0, 1, 2}},
-		{"from/to only", []int{2, 5}, []int{2, 3, 4}},
-		{"negative step", []int{5, 2, -1}, []int{5, 4, 3}},
-		{"step larger than range", []int{0, 5, 10}, []int{0}},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			var ch <-chan int
-			switch len(c.args) {
-			case 1:
-				ch = FromRange(c.args[0])
-			case 2:
-				ch = FromRange(c.args[0], c.args[1])
-			case 3:
-				ch = FromRange(c.args[0], c.args[1], c.args[2])
-			}
-			var result []int
-			for v := range ch {
-				result = append(result, v)
-			}
-			if len(c.expect) == 0 && len(result) == 0 {
-				return
-			}
-			if !reflect.DeepEqual(result, c.expect) {
-				t.Errorf("expected %v, got %v", c.expect, result)
-			}
-		})
-	}
-}
-
 func TestFromFunc(t *testing.T) {
 	// Example: generate values until cancelled
 	ctx, cancel := context.WithCancel(context.Background())

--- a/examples/01-channel/main.go
+++ b/examples/01-channel/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	// Create an input channel
-	in := channel.FromRange(10)
+	in := channel.FromValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 	// Filter even numbers only
 	filtered := channel.Filter(in, func(i int) bool {

--- a/examples/02-pipe/main.go
+++ b/examples/02-pipe/main.go
@@ -16,7 +16,11 @@ func main() {
 	defer cancel()
 
 	// Create input channel with string representations of integers
-	in := channel.Transform(channel.FromRange(20), func(i int) string {
+	ints := make([]int, 20)
+	for i := range ints {
+		ints[i] = i
+	}
+	in := channel.Transform(channel.FromSlice(ints), func(i int) string {
 		return strconv.Itoa(i)
 	})
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Learn gopipe step-by-step.
 
 | # | Example | Concepts |
 |---|---------|----------|
-| 1 | [channel](01-channel/) | Filter, Transform, Sink, FromRange |
+| 1 | [channel](01-channel/) | Filter, Transform, Sink, FromValues |
 | 2 | [pipe](02-pipe/) | ProcessPipe, Config, Middleware |
 | 3 | [merger](03-merger/) | Dynamic inputs, shutdown timeout |
 | 4 | [message](04-message/) | CloudEvents engine, handlers, routing |


### PR DESCRIPTION
## Summary

- Removed `channel.FromRange` — it faked Python's `range()` via argument-count dispatch (0/1/2/3 args) with panic-based validation, the only function in `channel` with this pattern
- Updated the two example call sites (`examples/01-channel`, `examples/02-pipe`) to use `FromValues`/`FromSlice` instead
- Updated `channel/doc.go` (Quick Start snippet and Sources category list) and `examples/README.md`
- Added CHANGELOG entry under `[Unreleased] → Removed`

## Test plan

- [x] `make test` passes
- [x] `make build` passes
- [x] `make vet` passes
- [x] Manually ran `examples/01-channel` and `examples/02-pipe` to confirm correct output after the `FromValues`/`FromSlice` swap

Closes #160

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeiPYNUNkT6x3qbbLka97c)_