### PR TITLE
fix(channel): make ToSlice return <-chan []T consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **channel:** Renamed `Route` → `Switch` (breaking, pre-v1) — avoids naming collision with `message.Router`, which does event-type-based routing (a different mechanism). Behavior is unchanged. (#165)
+- **channel:** `ToSlice` now returns `<-chan []T` instead of blocking synchronously and returning `[]T` (breaking, pre-v1) — matches the rest of the package's "launch goroutine, return channel" convention. The returned channel is closed after the slice is sent, so both `slice := <-channel.ToSlice(in)` and `for slice := range channel.ToSlice(in)` work. (#163)
 
 ### Removed
 

--- a/channel/to.go
+++ b/channel/to.go
@@ -1,13 +1,20 @@
 package channel
 
 // ToSlice collects all values from the input channel into a slice.
-// It blocks until the input channel is closed.
+// The returned channel is closed after the slice is collected.
 func ToSlice[T any](
 	in <-chan T,
-) []T {
-	var slice []T
-	for val := range in {
-		slice = append(slice, val)
-	}
-	return slice
+) <-chan []T {
+	out := make(chan []T)
+
+	go func() {
+		defer close(out)
+		var slice []T
+		for val := range in {
+			slice = append(slice, val)
+		}
+		out <- slice
+	}()
+
+	return out
 }

--- a/channel/to_test.go
+++ b/channel/to_test.go
@@ -13,7 +13,7 @@ func TestToSlice_Ints(t *testing.T) {
 	in <- 3
 	close(in)
 
-	slice := channel.ToSlice(in)
+	slice := <-channel.ToSlice(in)
 
 	if len(slice) != 3 {
 		t.Errorf("Expected slice length 3, got %d", len(slice))
@@ -27,7 +27,7 @@ func TestToSlice_Empty(t *testing.T) {
 	in := make(chan string)
 	close(in)
 
-	slice := channel.ToSlice(in)
+	slice := <-channel.ToSlice(in)
 
 	if len(slice) != 0 {
 		t.Errorf("Expected empty slice, got %v", slice)
@@ -40,12 +40,32 @@ func TestToSlice_Strings(t *testing.T) {
 	in <- "bar"
 	close(in)
 
-	slice := channel.ToSlice(in)
+	slice := <-channel.ToSlice(in)
 
 	if len(slice) != 2 {
 		t.Errorf("Expected slice length 2, got %d", len(slice))
 	}
 	if slice[0] != "foo" || slice[1] != "bar" {
 		t.Errorf("Expected [foo bar], got %v", slice)
+	}
+}
+
+func TestToSlice_RangeTerminates(t *testing.T) {
+	in := make(chan int, 3)
+	in <- 1
+	in <- 2
+	in <- 3
+	close(in)
+
+	var got []int
+	for slice := range channel.ToSlice(in) {
+		got = slice
+	}
+
+	if len(got) != 3 {
+		t.Errorf("Expected slice length 3, got %d", len(got))
+	}
+	if got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("Expected [1 2 3], got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `channel.ToSlice` now spawns a goroutine and returns `<-chan []T` instead of blocking synchronously and returning a raw `[]T`, matching the rest of the package's convention (`Sink`, `Drain`, etc.).
- The output channel is closed after the slice is sent, so both `slice := <-channel.ToSlice(in)` and `for slice := range channel.ToSlice(in)` work correctly.
- Updated `channel/to_test.go` call sites and added `TestToSlice_RangeTerminates` covering the range-termination acceptance criterion.
- Added a CHANGELOG entry under `[Unreleased]` (breaking, pre-v1).
- No other call sites of `ToSlice` exist elsewhere in the repo (examples, message, pipe packages); `channel/doc.go` only references the name, no change needed.

Closes #163. Tracked under #164.

Branched from `develop` (not `main`) per repo procedures — the prior automated attempts (`claude/issue-163-20260728-1729`, `claude/issue-163-20260728-1734`) were created from `main` and could not be rebased from their sandbox.

## Test plan

- [x] `make test` passes
- [x] `make build` passes
- [x] `make vet` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChMaAD2Aqfw6p1kSMe31N1)_