### PR TITLE
refactor(message): drop Router.AddHandler's matcher parameter

### DIFF
--- a/.claude/skills/building-message-pipelines/SKILL.md
+++ b/.claude/skills/building-message-pipelines/SKILL.md
@@ -34,7 +34,7 @@ router := message.NewRouter(message.PipeConfig{
 ## Adding Handlers
 
 ```go
-router.AddHandler("handler-name", matcher, message.NewCommandHandler(
+router.AddHandler("handler-name", message.NewCommandHandler(
     func(ctx context.Context, cmd InputType) ([]OutputType, error) {
         return []OutputType{{...}}, nil
     },

--- a/.claude/skills/developing-go-code/SKILL.md
+++ b/.claude/skills/developing-go-code/SKILL.md
@@ -23,7 +23,7 @@ make check  # All of the above
 | Context | Pattern | Example |
 |---------|---------|---------|
 | Constructors | Config struct | `NewRouter(PipeConfig{})` |
-| Methods | Direct parameters | `AddHandler("name", matcher, h)` |
+| Methods | Direct parameters | `AddHandler("name", h)` |
 | Optional filtering | `nil` = match all | `AddOutput("out", nil)` |
 
 ## Godoc Standards
@@ -99,7 +99,7 @@ Handler should NOT own its name — name is a wiring concern:
 type Handler interface { Name() string }
 
 // CORRECT - name is parameter to AddHandler
-router.AddHandler("process-orders", matcher, handler)
+router.AddHandler("process-orders", handler)
 ```
 
 ### Copy() sharing Attributes map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ TypedInputs ───────────┘                          │
 | Context | Pattern | Example |
 |---------|---------|---------|
 | Constructors | Config struct | `NewRouter(PipeConfig{})` |
-| Methods | Direct parameters | `AddHandler("name", matcher, h)` |
+| Methods | Direct parameters | `AddHandler("name", h)` |
 | Optional filtering | `nil` = match all | `AddOutput("out", nil)` |
 
 ### Matcher Interface
@@ -168,7 +168,7 @@ Handler should NOT own its name. Name is a wiring concern handled by Router:
 type Handler interface { Name() string }
 
 // CORRECT - name is parameter to AddHandler
-engine.AddHandler("process-orders", matcher, handler)
+router.AddHandler("process-orders", handler)
 ```
 
 ### ❌ Copy() sharing Attributes map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **message:** `ErrInputRejected` (only used by `Engine`'s input matcher). Breaking change, pre-v1. (#147)
 - **message/cloudevents:** `SubscriberPlugin`, `PublisherPlugin` (pure `Engine`-wiring sugar). Breaking change, pre-v1. Use `Subscriber`/`Publisher` directly. (#147)
 - **message/middleware:** `Subject()` removed entirely (breaking, pre-v1) — depended on typed `Data`, which `Router`-level middleware can no longer safely assume. Its capability moves to `CommandHandlerConfig.Subject`, called on the typed output value before marshaling. (#149)
+- **message:** `Router.AddHandler`'s `matcher Matcher` parameter (`AddHandler(name string, h Handler) error`, was `AddHandler(name string, matcher Matcher, h Handler) error`); `ErrHandlerRejected`. This was `Engine`-inherited plumbing with zero real (non-test) call sites — every consumer passed `nil`. Breaking change, pre-v1. Filter inside the handler's own `Handle()` (or command function, via `MessageFromContext(ctx).Attributes`) instead. (#152)
 
 ## [0.18.0] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ handler := message.NewCommandHandler(
     },
     message.CommandHandlerConfig{Source: "/orders"},
 )
-router.AddHandler("orders", nil, handler)
+router.AddHandler("orders", handler)
 
 output, _ := router.Pipe(ctx, input)
 ```

--- a/docs/patterns/cqrs.md
+++ b/docs/patterns/cqrs.md
@@ -67,8 +67,8 @@ handler := message.NewHandler[OrderCreated](
 ```go
 router := message.NewRouter(message.PipeConfig{})
 
-router.AddHandler("create-order", nil, createOrderHandler)
-router.AddHandler("order-projection", nil, orderCreatedHandler)
+router.AddHandler("create-order", createOrderHandler)
+router.AddHandler("order-projection", orderCreatedHandler)
 
 input := make(chan *message.Message)
 marshaler := message.NewJSONMarshaler()

--- a/examples/04-message/main.go
+++ b/examples/04-message/main.go
@@ -63,7 +63,7 @@ func basicRouting() {
 			Naming: message.DotNaming, // CreateOrder → "create.order"
 		},
 	)
-	router.AddHandler("process-order", nil, handler)
+	router.AddHandler("process-order", handler)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -131,7 +131,7 @@ func pureHeterogeneousHandler() {
 		Source: "/seeding",
 		Naming: message.DotNaming, // ExpiredEvent → "expired.event"
 	})
-	router.AddHandler("expired-transform", nil, handler)
+	router.AddHandler("expired-transform", handler)
 	_ = router.Use(middleware.CorrelationID())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/examples/06-http-cloudevents/main.go
+++ b/examples/06-http-cloudevents/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// Setup router with handler: OrderCreated → OrderConfirmed
 	router := message.NewRouter(message.PipeConfig{})
-	router.AddHandler("process-order", nil, message.NewCommandHandler(
+	router.AddHandler("process-order", message.NewCommandHandler(
 		func(ctx context.Context, order OrderCreated) ([]OrderConfirmed, error) {
 			fmt.Printf("Processing: %s ($%d)\n", order.OrderID, order.Amount)
 			return []OrderConfirmed{{

--- a/examples/07-validating-marshaler/main.go
+++ b/examples/07-validating-marshaler/main.go
@@ -122,7 +122,7 @@ func main() {
 
 	// 4. Router: handle messages and produce new messages.
 	router := message.NewRouter(message.PipeConfig{})
-	router.AddHandler("process-order", nil, message.NewCommandHandler(
+	router.AddHandler("process-order", message.NewCommandHandler(
 		func(ctx context.Context, cmd CreateOrderCommand) ([]OrderCreatedEvent, error) {
 			log.Printf("Processing order: %s ($%.2f)", cmd.OrderID, cmd.Amount)
 			return []OrderCreatedEvent{{

--- a/message/README.md
+++ b/message/README.md
@@ -55,7 +55,7 @@ handler := message.NewCommandHandler(
         Naming: message.DotNaming,
     },
 )
-router.AddHandler("orders", nil, handler)
+router.AddHandler("orders", handler)
 
 ctx, cancel := context.WithCancel(context.Background())
 defer cancel()
@@ -87,7 +87,7 @@ handler := message.NewCommandHandler(
         DisableMarshaler: true,
     },
 )
-router.AddHandler("orders", nil, handler)
+router.AddHandler("orders", handler)
 
 // Typed input/output, no marshal/unmarshal
 input := make(chan *message.Message, 100)

--- a/message/cloudevents/README.md
+++ b/message/cloudevents/README.md
@@ -27,7 +27,7 @@ pub := cloudevents.NewPublisher(sender, cloudevents.PublisherConfig{})
 
 // Wire raw input through Router via unmarshal/marshal pipes
 router := message.NewRouter(message.PipeConfig{})
-router.AddHandler("orders", nil, handler)
+router.AddHandler("orders", handler)
 
 rawIn, _ := sub.Subscribe(ctx)
 unmarshal := message.NewUnmarshalPipe(router, message.NewJSONMarshaler(), message.PipeConfig{})

--- a/message/cloudevents/doc.go
+++ b/message/cloudevents/doc.go
@@ -19,7 +19,7 @@
 //	rawIn, _ := sub.Subscribe(ctx)
 //
 //	router := message.NewRouter(message.PipeConfig{})
-//	router.AddHandler("orders", nil, handler)
+//	router.AddHandler("orders", handler)
 //
 //	unmarshal := message.NewUnmarshalPipe(router, message.NewJSONMarshaler(), message.PipeConfig{})
 //	typedIn, _ := unmarshal.Pipe(ctx, rawIn)

--- a/message/doc.go
+++ b/message/doc.go
@@ -21,7 +21,7 @@
 //		},
 //		message.CommandHandlerConfig{Source: "/orders", Naming: message.DotNaming},
 //	)
-//	router.AddHandler("orders", nil, handler)
+//	router.AddHandler("orders", handler)
 //
 //	output, _ := router.Pipe(ctx, rawInputCh)
 //

--- a/message/errors.go
+++ b/message/errors.go
@@ -12,9 +12,6 @@ var (
 	// ErrNoHandler is returned when no handler exists for a message type.
 	ErrNoHandler = errors.New("no handler for message type")
 
-	// ErrHandlerRejected is returned when a message is rejected by handler matcher.
-	ErrHandlerRejected = errors.New("message rejected by handler matcher")
-
 	// ErrUnknownType is returned when unmarshaling a message with unknown type.
 	ErrUnknownType = errors.New("unknown message type")
 

--- a/message/middleware/correlation_test.go
+++ b/message/middleware/correlation_test.go
@@ -44,7 +44,7 @@ func TestCorrelationID(t *testing.T) {
 			}, nil
 		}, message.DotNaming)
 
-		if err := router.AddHandler("test", nil, handler); err != nil {
+		if err := router.AddHandler("test", handler); err != nil {
 			t.Fatalf("AddHandler failed: %v", err)
 		}
 
@@ -100,7 +100,7 @@ func TestCorrelationID(t *testing.T) {
 			}, nil
 		}, message.DotNaming)
 
-		if err := router.AddHandler("test", nil, handler); err != nil {
+		if err := router.AddHandler("test", handler); err != nil {
 			t.Fatalf("AddHandler failed: %v", err)
 		}
 
@@ -138,7 +138,7 @@ func TestUse_AfterStart(t *testing.T) {
 	handler := message.NewHandler[TestCommand](func(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
 		return nil, nil
 	}, message.DotNaming)
-	_ = router.AddHandler("test", nil, handler)
+	_ = router.AddHandler("test", handler)
 
 	input := make(chan *message.Message)
 

--- a/message/router.go
+++ b/message/router.go
@@ -22,7 +22,6 @@ type Middleware func(ProcessFunc) ProcessFunc
 // handlerEntry holds a handler and its configuration.
 type handlerEntry struct {
 	name    string
-	matcher Matcher
 	handler Handler
 }
 
@@ -135,8 +134,7 @@ func NewRouter(cfg PipeConfig) *Router {
 }
 
 // AddHandler registers a handler.
-// The optional matcher is applied after type matching.
-func (r *Router) AddHandler(name string, matcher Matcher, h Handler) error {
+func (r *Router) AddHandler(name string, h Handler) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.started {
@@ -146,7 +144,7 @@ func (r *Router) AddHandler(name string, matcher Matcher, h Handler) error {
 	if _, exists := r.handlers[eventType]; exists {
 		return ErrHandlerExists
 	}
-	r.handlers[eventType] = handlerEntry{name: name, matcher: matcher, handler: h}
+	r.handlers[eventType] = handlerEntry{name: name, handler: h}
 	r.cfg.Logger.Info("Adding handler",
 		"component", "router",
 		"handler", name,
@@ -238,7 +236,7 @@ func (r *Router) handler(eventType string) (handlerEntry, bool) {
 }
 
 func (r *Router) process(ctx context.Context, msg *Message) ([]*Message, error) {
-	// handler lookup → matcher check → handler.Handle
+	// handler lookup → handler.Handle
 	// Messages are auto-nacked on error (consistent with other components).
 	// Acking on success is the handler's responsibility. Use AutoAck middleware
 	// for automatic ack-on-success behavior.
@@ -247,16 +245,6 @@ func (r *Router) process(ctx context.Context, msg *Message) ([]*Message, error) 
 		err := ErrNoHandler
 		r.cfg.Logger.Error("Routing message failed",
 			"component", "router",
-			"error", err,
-			"attributes", msg.Attributes)
-		return nil, err
-	}
-
-	if entry.matcher != nil && !entry.matcher.Match(msg.Attributes) {
-		err := ErrHandlerRejected
-		r.cfg.Logger.Error("Matching handler failed",
-			"component", "router",
-			"handler", entry.name,
 			"error", err,
 			"attributes", msg.Attributes)
 		return nil, err

--- a/message/router_test.go
+++ b/message/router_test.go
@@ -21,7 +21,7 @@ func TestRouter_BasicRouting(t *testing.T) {
 		}, nil
 	}, DotNaming)
 
-	_ = router.AddHandler("", nil, handler)
+	_ = router.AddHandler("", handler)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -86,56 +86,6 @@ func TestRouter_NoHandler(t *testing.T) {
 	}
 }
 
-func TestRouter_HandlerMatcher(t *testing.T) {
-	var handledErr error
-	router := NewRouter(PipeConfig{
-		ErrorHandler: func(msg *Message, err error) {
-			handledErr = err
-		},
-	})
-
-	handler := NewHandler[TestCommand](func(ctx context.Context, msg *Message) ([]*Message, error) {
-		return []*Message{{Data: msg.Data, Attributes: msg.Attributes}}, nil
-	}, DotNaming)
-
-	// Add handler with matcher that rejects messages without "allowed" attribute
-	_ = router.AddHandler("", matcherFunc(func(attrs Attributes) bool {
-		_, ok := attrs["allowed"]
-		return ok
-	}), handler)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	in := make(chan *Message, 2)
-	// This one will be rejected by matcher
-	in <- &Message{
-		Data:       &TestCommand{ID: "1", Name: "rejected"},
-		Attributes: Attributes{"type": "test.command"},
-	}
-	// This one will pass
-	in <- &Message{
-		Data:       &TestCommand{ID: "2", Name: "allowed"},
-		Attributes: Attributes{"type": "test.command", "allowed": true},
-	}
-	close(in)
-
-	out, _ := router.Pipe(ctx, in)
-
-	var received []*Message
-	for msg := range out {
-		received = append(received, msg)
-	}
-
-	if len(received) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(received))
-	}
-
-	if !errors.Is(handledErr, ErrHandlerRejected) {
-		t.Errorf("expected ErrHandlerRejected, got %v", handledErr)
-	}
-}
-
 func TestRouter_HandlerError(t *testing.T) {
 	testErr := errors.New("handler error")
 	var handledErr error
@@ -150,7 +100,7 @@ func TestRouter_HandlerError(t *testing.T) {
 		return nil, testErr
 	}, DotNaming)
 
-	_ = router.AddHandler("", nil, handler)
+	_ = router.AddHandler("", handler)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -185,7 +135,7 @@ func TestRouter_MultipleOutputs(t *testing.T) {
 		}, nil
 	}, DotNaming)
 
-	_ = router.AddHandler("", nil, handler)
+	_ = router.AddHandler("", handler)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -216,7 +166,7 @@ func TestRouter_ContextCancellation(t *testing.T) {
 		return []*Message{{Data: msg.Data, Attributes: msg.Attributes}}, nil
 	}, DotNaming)
 
-	_ = router.AddHandler("", nil, handler)
+	_ = router.AddHandler("", handler)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -273,7 +223,7 @@ func TestRouter_Standalone(t *testing.T) {
 		}, nil
 	}, DotNaming)
 
-	_ = router.AddHandler("", nil, handler)
+	_ = router.AddHandler("", handler)
 
 	ctx := context.Background()
 	in := make(chan *Message, 1)
@@ -444,8 +394,8 @@ func TestRouter_DuplicateHandler(t *testing.T) {
 		return nil, nil
 	}, DotNaming)
 
-	_ = router.AddHandler("test1", nil, handler1)
-	err := router.AddHandler("test2", nil, handler2)
+	_ = router.AddHandler("test1", handler1)
+	err := router.AddHandler("test2", handler2)
 	if !errors.Is(err, ErrHandlerExists) {
 		t.Errorf("expected ErrHandlerExists, got %v", err)
 	}
@@ -489,7 +439,7 @@ func TestRouter_AckStrategy_Default(t *testing.T) {
 		handler := NewHandler[TestCommand](func(ctx context.Context, msg *Message) ([]*Message, error) {
 			return nil, nil // Success
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -521,7 +471,7 @@ func TestRouter_AckStrategy_Default(t *testing.T) {
 		handler := NewHandler[TestCommand](func(ctx context.Context, msg *Message) ([]*Message, error) {
 			return nil, errors.New("handler error")
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -556,7 +506,7 @@ func TestRouter_AckStrategy_Manual(t *testing.T) {
 			msg.Ack() // Manual ack
 			return nil, nil
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -585,7 +535,7 @@ func TestRouter_AckStrategy_Manual(t *testing.T) {
 		handler := NewHandler[TestCommand](func(ctx context.Context, msg *Message) ([]*Message, error) {
 			return nil, errors.New("handler error")
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -619,7 +569,7 @@ func TestRouter_AckStrategy_Forward(t *testing.T) {
 				{Data: "out2", Attributes: Attributes{"type": "output"}},
 			}, nil
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -663,7 +613,7 @@ func TestRouter_AckStrategy_Forward(t *testing.T) {
 				{Data: "out2", Attributes: Attributes{"type": "output"}},
 			}, nil
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -715,7 +665,7 @@ func TestRouter_AckingMiddleware_Outermost(t *testing.T) {
 			order = append(order, "handler")
 			return nil, nil
 		}, DotNaming)
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -765,7 +715,7 @@ func TestRouter_ProcessTimeout(t *testing.T) {
 			}
 		}, DotNaming)
 
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -806,7 +756,7 @@ func TestRouter_ProcessTimeout(t *testing.T) {
 			}}, nil
 		}, DotNaming)
 
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -846,7 +796,7 @@ func TestRouter_ProcessTimeout(t *testing.T) {
 			}}, nil
 		}, DotNaming)
 
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx := context.Background()
 		in := make(chan *Message, 1)
@@ -891,7 +841,7 @@ func TestRouter_ProcessTimeout(t *testing.T) {
 			}
 		}, DotNaming)
 
-		_ = router.AddHandler("", nil, handler)
+		_ = router.AddHandler("", handler)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		in := make(chan *Message, 1)
@@ -942,7 +892,7 @@ func TestRouter_Stats_BeforeStart(t *testing.T) {
 func TestRouter_Stats_AfterStart(t *testing.T) {
 	t.Parallel()
 	r := NewRouter(PipeConfig{Pool: PoolConfig{BufferSize: 8}})
-	_ = r.AddHandler("", nil, NewHandler[TestCommand](func(_ context.Context, _ *Message) ([]*Message, error) {
+	_ = r.AddHandler("", NewHandler[TestCommand](func(_ context.Context, _ *Message) ([]*Message, error) {
 		return nil, nil
 	}, DotNaming))
 
@@ -964,7 +914,7 @@ func TestRouter_Stats_AfterStart(t *testing.T) {
 func TestRouter_Stats_ConcurrentWithPipe(t *testing.T) {
 	// Run with -race to detect concurrent read/write on r.inner.
 	r := NewRouter(PipeConfig{Pool: PoolConfig{BufferSize: 4}})
-	_ = r.AddHandler("", nil, NewHandler[TestCommand](func(_ context.Context, _ *Message) ([]*Message, error) {
+	_ = r.AddHandler("", NewHandler[TestCommand](func(_ context.Context, _ *Message) ([]*Message, error) {
 		return nil, nil
 	}, DotNaming))
 


### PR DESCRIPTION
## Summary

- `Router.AddHandler` drops its `matcher Matcher` parameter — `AddHandler(name string, h Handler) error` (was `AddHandler(name string, matcher Matcher, h Handler) error`)
- Removes the `entry.matcher` rejection check from `Router.process()`
- Removes `ErrHandlerRejected` (dead code, no other caller)
- Updates `TestRouter_HandlerMatcher` (removed — the feature it tested no longer exists) and all other `AddHandler` call sites in tests/examples
- Updates docs showing the old three-arg signature

This parameter traced back to `Engine`'s design (removed in #147), not an independent `Router` requirement. Every real (non-test) call site in the repo passed `nil`, and the only test exercising rejection used a test-only `matcherFunc`, not the real `message/match` package. Since `Router` allows exactly one handler per event type, per-handler filtering is already fully expressible inside the handler's own `Handle()` (via `msg.Attributes` or `MessageFromContext(ctx).Attributes`), with no framework feature required.

Out of scope: the `Matcher` interface itself and `message/match` package remain untouched — their fate is decided separately in #153 (`Distributor.AddOutput` is still a real consumer until that lands).

## Test plan

- [x] `make test` — all packages pass
- [x] `make build` — succeeds
- [x] `make vet` — clean
- [x] `examples` module builds (`cd examples && go build ./...`)

Closes #152

---
_Generated by [Claude Code](https://claude.ai/code/session_01H75sU3iLYjARfc1fzQDJFd)_